### PR TITLE
Make a flatpak compatible module  (#7)

### DIFF
--- a/.github/actions/gen_release_notes/action.yml
+++ b/.github/actions/gen_release_notes/action.yml
@@ -1,0 +1,51 @@
+name: Generate Release Notes
+description: Generate formatted GitHub release notes from CHANGELOG.md
+
+inputs:
+  version:
+    description: Version string (v-prefix is stripped automatically)
+    required: true
+  package_name:
+    description: Display name of the package used in the release title
+    required: false
+    default: ${{ github.event.repository.name }}
+  repository:
+    description: GitHub repository in owner/repo format
+    required: false
+    default: ${{ github.repository }}
+  changelog:
+    description: Path to CHANGELOG.md relative to workspace root
+    required: false
+    default: CHANGELOG.md
+  output_file:
+    description: File path where the generated notes are written
+    required: false
+    default: /tmp/release_notes.md
+
+outputs:
+  notes_file:
+    description: Path to the generated release notes file
+    value: ${{ steps.gen.outputs.notes_file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      with:
+        enable-cache: "false"
+
+    - name: Generate release notes
+      id: gen
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        VERSION="${VERSION#v}"
+        uv run python "${{ github.action_path }}/gen_release_notes.py" \
+          "$VERSION" \
+          "${{ inputs.repository }}" \
+          "${{ inputs.changelog }}" \
+          "${{ inputs.package_name }}" > "${{ inputs.output_file }}"
+        echo "notes_file=${{ inputs.output_file }}" >> "$GITHUB_OUTPUT"
+        echo "--- release notes preview ---"
+        cat "${{ inputs.output_file }}"

--- a/.github/actions/gen_release_notes/gen_release_notes.py
+++ b/.github/actions/gen_release_notes/gen_release_notes.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Generate formatted GitHub release notes from CHANGELOG.md.
+
+Usage:
+    python scripts/gen_release_notes.py <version> <repo> [changelog]
+
+Supports optional sections in CHANGELOG.md within a version/Unreleased block:
+
+    ## [Unreleased]
+
+    > One-line description shown below the release title.
+
+    ### Upgrade Notes
+    Backward-compatibility notes, migration steps, etc.
+
+    ### Changed
+    - ...
+
+    ### Fixed
+    - ...
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+def extract_section(text: str, version: str) -> str:
+    escaped = re.escape(version)
+    patterns = [
+        rf"^## \[?v?{escaped}\]?(?:\s|$)",
+        r"^## \[?[Uu]nreleased\]?(?:\s|$)",
+    ]
+    for pattern in patterns:
+        m = re.search(pattern, text, re.MULTILINE)
+        if not m:
+            continue
+        # skip the rest of the matched header line
+        nl = text.find("\n", m.start())
+        start = nl + 1 if nl != -1 else m.end()
+        next_m = re.search(r"^## ", text[start:], re.MULTILINE)
+        end = start + next_m.start() if next_m else len(text)
+        section = text[start:end].strip()
+        if section:
+            return section
+    return ""
+
+
+def parse_intro(section: str) -> str:
+    for line in section.splitlines():
+        if line.startswith(">"):
+            return line.lstrip(">").strip()
+    return ""
+
+
+def parse_subsection(section: str, name: str) -> str:
+    m = re.search(rf"^### {re.escape(name)}\s*$", section, re.MULTILINE)
+    if not m:
+        return ""
+    start = m.end()
+    next_m = re.search(r"^### ", section[start:], re.MULTILINE)
+    end = start + next_m.start() if next_m else len(section)
+    return section[start:end].strip()
+
+
+_CHANGELOG_NOISE = re.compile(r"^\[!\[|^\[:[a-z]")  # badges, mkdocs snippets
+
+
+def parse_highlights(section: str) -> str:
+    lines, skip = [], False
+    for line in section.splitlines():
+        if line.startswith(">") or _CHANGELOG_NOISE.match(line):
+            continue
+        if re.match(r"^### Upgrade Notes\s*$", line):
+            skip = True
+            continue
+        if skip and re.match(r"^### ", line):
+            skip = False
+        if not skip:
+            lines.append(line)
+    return "\n".join(lines).strip()
+
+
+def get_prev_tag(version: str) -> Optional[str]:
+    try:
+        tags = subprocess.check_output(["git", "tag", "--sort=-version:refname"], text=True).splitlines()
+        exclude = {version, f"v{version}"}
+        return next((t.strip() for t in tags if t.strip() and t.strip() not in exclude), None)
+    except subprocess.CalledProcessError:
+        return None
+
+
+def get_contributors(prev_tag: Optional[str]) -> List[str]:
+    try:
+        ref = f"{prev_tag}..HEAD" if prev_tag else "HEAD"
+        names = subprocess.check_output(["git", "log", ref, "--format=%aN"], text=True).splitlines()
+        return sorted({n for n in names if n and "github-actions" not in n.lower()})
+    except subprocess.CalledProcessError:
+        return []
+
+
+TEMPLATE = """\
+# 📦 {package_name} v{version}
+{intro}
+## 🚀 Highlights
+
+{highlights}
+{upgrade_section}
+{contributors_section}
+## 🔗 Full Changelog
+
+{changelog_link}
+"""
+
+
+def generate(version: str, repo: str, changelog_path: Path, package_name: str) -> str:
+    text = changelog_path.read_text(encoding="utf-8")
+    section = extract_section(text, version)
+    if not section:
+        sys.exit(f"Error: no changelog section found for version {version!r}")
+
+    intro = parse_intro(section)
+    upgrade_notes = parse_subsection(section, "Upgrade Notes")
+    highlights = parse_highlights(section)
+    prev_tag = get_prev_tag(version)
+    contributors = get_contributors(prev_tag)
+
+    if prev_tag:
+        url = f"https://github.com/{repo}/compare/{prev_tag}...v{version}"
+        changelog_link = f"👉 [Compare {prev_tag}...v{version}]({url})"
+    else:
+        changelog_link = f"👉 https://github.com/{repo}/releases/tag/v{version}"
+
+    contributor_list = "\n".join(f"* @{c}" for c in contributors)
+
+    notes = TEMPLATE.format(
+        package_name=package_name,
+        version=version,
+        intro=intro,
+        highlights=highlights,
+        upgrade_section=f"## 🛠 Upgrade Notes\n\n{upgrade_notes}\n" if upgrade_notes else "",
+        contributors_section=(
+            f"## 📜 Contributors\n\nSpecial thanks to everyone who contributed to this release:\n\n{contributor_list}\n"
+            if contributors else ""
+        ),
+        changelog_link=changelog_link,
+    )
+    return re.sub(r"\n{3,}", "\n\n", notes).strip() + "\n"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <version> <repo> [changelog] [package_name]", file=sys.stderr)
+        sys.exit(1)
+
+    _version = sys.argv[1].lstrip("v")
+    _repo = sys.argv[2]
+    _changelog = Path(sys.argv[3]) if len(sys.argv) > 3 else Path("CHANGELOG.md")
+    _package_name = sys.argv[4] if len(sys.argv) > 4 else _repo.split("/")[-1]
+
+    sys.stdout.write(generate(_version, _repo, _changelog, _package_name))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,34 @@ jobs:
       arch: arm64
       retention_days: 1
 
+  update-flatpak-module:
+    name: Update Flatpak Module
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update bclibc.json
+        run: |
+          TAG=${{ github.ref_name }}
+          COMMIT=$(git rev-list -n1 "$TAG")
+          jq --arg tag "$TAG" --arg commit "$COMMIT" \
+            '(.sources[] | select(.type == "git")) |= (.tag = $tag | .commit = $commit)' \
+            bclibc.json > bclibc.json.tmp && mv bclibc.json.tmp bclibc.json
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bclibc.json
+          git diff --staged --quiet || git commit -m "chore: update Flatpak module to ${{ github.ref_name }} [skip ci]"
+          git push
+
   release:
     name: Create Release
     needs:
@@ -56,6 +84,9 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Delete existing release if present
         run: gh release delete ${{ github.ref_name }} --yes || true
         env:
@@ -71,6 +102,18 @@ jobs:
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          VERSION=${{ steps.get_version.outputs.version }}
+          BODY=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{found=0} found" CHANGELOG.md | sed '/^[[:space:]]*$/d' | head -50)
+          if [ -z "$BODY" ]; then
+            BODY="See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details."
+          fi
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Package artifacts into zips
         run: |
@@ -88,4 +131,4 @@ jobs:
           draft: false
           prerelease: false
           files: release-files/*.zip
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.body }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.5] - 2026-05-14
+
+### Added
+- Flatpak module descriptor (`bclibc.json`) for use in Flatpak/Flathub projects
+- CMake install rules (`GNUInstallDirs`) — `cmake --install` now installs headers, libraries and cmake package config to prefix
+- CMake package export (`find_package(bclibc)`) via `bclibc-config.cmake` and `bclibc-targets.cmake`
+- `BCLIBC_BUILD_TESTS` cmake option
+
+### Changed
+- `git describe` no longer uses `--dirty` flag (required for Flathub sandbox builds)
+- Source files listed explicitly instead of `GLOB_RECURSE`
+- `target_include_directories` uses generator expressions for correct install-tree paths
+
+### CI
+- Auto-update `bclibc.json` on every release tag via GitHub Actions
+
+## [1.0.4] - 2026-04-20
+
+### Changed
+- Replaced Ukrainian source code comments with English
+
+## [1.0.3] - 2026-04-11
+
+### Added
+- `ffi_call<F>` template replacing `BCLIBCFFI_CATCH` macro — uniform catch logic across FFI boundary including non-std exceptions
+
+### Changed
+- `try_get_exact` return type changed from `void` (exception-as-control-flow) to `bool`; call sites converted from `try/catch` to plain `if` checks
+- `build_pchip_curve_from_arrays` extracted into `base_types.hpp`/`base_types.cpp` eliminating code duplication between Cython and FFI paths
+
+### CI
+- Multi-platform build support (Linux x86\_64/arm64, Windows x86\_64/arm64, macOS universal)
+- Fixed release assets upload
+
+## [1.0.2] - 2026-03-30
+
+### CI
+- Added cross-platform CI builds for Linux, Windows and macOS
+
+## [1.0.1] - 2026-03-25
+
+### Added
+- `build_pchip_curve_from_arrays` FFI function
+- `buildCurve` FFI wrapper
+
+## [1.0.0] - 2026-03-23
+
+### Added
+- Initial release
+
+[Unreleased]: https://github.com/ballistics-lab/bclibc/compare/v1.0.5...HEAD
+[1.0.5]: https://github.com/ballistics-lab/bclibc/compare/v1.0.4...v1.0.5
+[1.0.4]: https://github.com/ballistics-lab/bclibc/compare/v1.0.3...v1.0.4
+[1.0.3]: https://github.com/ballistics-lab/bclibc/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/ballistics-lab/bclibc/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/ballistics-lab/bclibc/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/ballistics-lab/bclibc/releases/tag/v1.0.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ============================================================================
+# Options
+# ============================================================================
+option(BCLIBC_BUILD_TESTS "Build tests" OFF)
+
+# ============================================================================
 # Platform detection
 # ============================================================================
 if(WIN32)
@@ -29,7 +34,7 @@ set(BCLIBC_VERSION_STR "${BCLIBC_VERSION_MAJOR}.${BCLIBC_VERSION_MINOR}.${BCLIBC
 if(GIT_FOUND)
     # Get describe info. If no tags, it falls back to commit hash
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+        COMMAND ${GIT_EXECUTABLE} describe --tags --always
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         OUTPUT_VARIABLE GIT_TAG
         OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -67,16 +72,25 @@ configure_file(
 set(BCLIBC_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(BCLIBC_SRC_DIR     "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-# Core only, ignore ffi directory
-file(GLOB_RECURSE BCLIBC_SOURCES "${BCLIBC_SRC_DIR}/*.cpp")
-list(FILTER BCLIBC_SOURCES EXCLUDE REGEX "src/ffi/.*")
+set(BCLIBC_SOURCES
+    "${BCLIBC_SRC_DIR}/base_types.cpp"
+    "${BCLIBC_SRC_DIR}/engine.cpp"
+    "${BCLIBC_SRC_DIR}/euler.cpp"
+    "${BCLIBC_SRC_DIR}/interp.cpp"
+    "${BCLIBC_SRC_DIR}/rk4.cpp"
+    "${BCLIBC_SRC_DIR}/traj_data.cpp"
+    "${BCLIBC_SRC_DIR}/traj_filter.cpp"
+)
 
 # ============================================================================
 # 1. Target: Pure core (Static Library)
 # ============================================================================
 add_library(bclibc_core STATIC ${BCLIBC_SOURCES})
 
-target_include_directories(bclibc_core PUBLIC "${BCLIBC_INCLUDE_DIR}")
+target_include_directories(bclibc_core PUBLIC
+    "$<BUILD_INTERFACE:${BCLIBC_INCLUDE_DIR}>"
+    "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
+)
 target_include_directories(bclibc_core PRIVATE "${BCLIBC_SRC_DIR}")
 
 set_target_properties(bclibc_core PROPERTIES
@@ -176,20 +190,68 @@ if(LINUX_BUILD AND NOT CMAKE_BUILD_TYPE MATCHES "Debug")
     endif()
 endif()
 
+
 # ============================================================================
-# Export headers and libraries for Flutter
+# Installation rules
 # ============================================================================
-# This makes it easier for the main CMakeLists.txt to find the library
-if(WINDOWS_BUILD)
-    # Export include directory
-    set(BCLIBC_INCLUDE_DIRS "${BCLIBC_INCLUDE_DIR}" PARENT_SCOPE)
-    set(BCLIBC_LIBRARY_DIR "${CMAKE_BINARY_DIR}/bin" PARENT_SCOPE)
-    
-    # Create a config file for easier finding
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/bclibc-config.cmake.in"
-        "${CMAKE_BINARY_DIR}/bclibc-config.cmake"
-        @ONLY
-    )
-endif()
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+install(TARGETS bclibc_core bclibc_ffi
+    EXPORT bclibc-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/generated/bclibc/version.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bclibc
+)
+
+install(FILES "${BCLIBC_INCLUDE_DIR}/bclibc.hpp"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(FILES
+    "${BCLIBC_INCLUDE_DIR}/bclibc/base_types.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/engine.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/euler.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/exceptions.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/interp.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/log.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/rk4.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/scope_guard.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/traj_data.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/traj_filter.hpp"
+    "${BCLIBC_INCLUDE_DIR}/bclibc/v3d.hpp"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bclibc
+)
+
+install(FILES "${BCLIBC_INCLUDE_DIR}/bclibc/ffi/bclibc_ffi.h"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/bclibc/ffi
+)
+
+install(EXPORT bclibc-targets
+    FILE bclibc-targets.cmake
+    NAMESPACE bclibc::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bclibc
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/bclibc-config-version.cmake"
+    VERSION ${BCLIBC_VERSION_MAJOR}.${BCLIBC_VERSION_MINOR}.${BCLIBC_VERSION_PATCH}
+    COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/bclibc-config.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/bclibc-config.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bclibc
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/bclibc-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/bclibc-config-version.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/bclibc
+)
 

--- a/README.md
+++ b/README.md
@@ -196,3 +196,13 @@ chmod +x pre-commit-check.sh
 ├── version.h.in
 └── LICENSE
 ```
+
+
+> [!WARNING]
+>
+> ## RISK NOTICE
+>
+> This library performs approximate simulations of complex physical processes.
+> Therefore, the calculation results MUST NOT be considered as completely and reliably > reflecting actual behavior of projectiles. While these results may be used for educational purpose, they must NOT be considered as reliable for the areas where incorrect calculation may cause making a wrong decision, financial harm, or can put a human life at risk.
+> 
+> THE CODE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.

--- a/bclibc-config.cmake.in
+++ b/bclibc-config.cmake.in
@@ -1,39 +1,5 @@
-# bclibc-config.cmake.in
-set(BCLIBC_FOUND TRUE)
-set(BCLIBC_VERSION "@BCLIBC_VERSION@")
+@PACKAGE_INIT@
 
-# Include directories
-set(BCLIBC_INCLUDE_DIRS "@BCLIBC_INCLUDE_DIR@")
+include("${CMAKE_CURRENT_LIST_DIR}/bclibc-targets.cmake")
 
-# Libraries (platform specific)
-if(WIN32)
-    set(BCLIBC_FFI_LIBRARY "@CMAKE_BINARY_DIR@/bin/@CMAKE_BUILD_TYPE@/bclibc_ffi.dll")
-    set(BCLIBC_CORE_LIBRARY "@CMAKE_BINARY_DIR@/lib/@CMAKE_BUILD_TYPE@/bclibc_core.lib")
-    set(BCLIBC_LIBRARIES ${BCLIBC_FFI_LIBRARY} ${BCLIBC_CORE_LIBRARY})
-elseif(APPLE)
-    set(BCLIBC_FFI_LIBRARY "@CMAKE_BINARY_DIR@/libbclibc_ffi.dylib")
-    set(BCLIBC_CORE_LIBRARY "@CMAKE_BINARY_DIR@/libbclibc_core.a")
-    set(BCLIBC_LIBRARIES ${BCLIBC_FFI_LIBRARY} ${BCLIBC_CORE_LIBRARY})
-else()
-    set(BCLIBC_FFI_LIBRARY "@CMAKE_BINARY_DIR@/libbclibc_ffi.so")
-    set(BCLIBC_CORE_LIBRARY "@CMAKE_BINARY_DIR@/libbclibc_core.a")
-    set(BCLIBC_LIBRARIES ${BCLIBC_FFI_LIBRARY} ${BCLIBC_CORE_LIBRARY})
-endif()
-
-# Add the target if needed
-if(NOT TARGET bclibc::ffi)
-    add_library(bclibc::ffi SHARED IMPORTED)
-    set_target_properties(bclibc::ffi PROPERTIES
-        IMPORTED_LOCATION "${BCLIBC_FFI_LIBRARY}"
-        INTERFACE_INCLUDE_DIRECTORIES "@BCLIBC_INCLUDE_DIR@"
-    )
-endif()
-
-# Also add core library target for convenience
-if(NOT TARGET bclibc::core)
-    add_library(bclibc::core STATIC IMPORTED)
-    set_target_properties(bclibc::core PROPERTIES
-        IMPORTED_LOCATION "${BCLIBC_CORE_LIBRARY}"
-        INTERFACE_INCLUDE_DIRECTORIES "@BCLIBC_INCLUDE_DIR@"
-    )
-endif()
+check_required_components(bclibc)

--- a/bclibc.json
+++ b/bclibc.json
@@ -1,0 +1,16 @@
+{
+  "name": "bclibc",
+  "buildsystem": "cmake-ninja",
+  "config-opts": [
+    "-DCMAKE_BUILD_TYPE=Release",
+    "-DBCLIBC_BUILD_TESTS=OFF"
+  ],
+  "sources": [
+    {
+      "type": "git",
+      "url": "https://github.com/ballistics-lab/bclibc.git",
+      "tag": "v1.0.4",
+      "commit": "5669f35d9752c58fd93f110c4bc6a563cdc8cb51"
+    }
+  ]
+}


### PR DESCRIPTION
### Added
- Flatpak module descriptor (`bclibc.json`) for use in Flatpak/Flathub projects
- CMake install rules (`GNUInstallDirs`) — `cmake --install` now installs headers, libraries and cmake package config to prefix
- CMake package export (`find_package(bclibc)`) via `bclibc-config.cmake` and `bclibc-targets.cmake`
- `BCLIBC_BUILD_TESTS` cmake option

### Changed
- `git describe` no longer uses `--dirty` flag (required for Flathub sandbox builds)
- Source files listed explicitly instead of `GLOB_RECURSE`
- `target_include_directories` uses generator expressions for correct install-tree paths

### CI
- Auto-update `bclibc.json` on every release tag via GitHub Actions