### PR TITLE
feat: bclibc consilidation for wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `BCLIBC_Coriolis::from_lat_az(lat_deg, muzzle_velocity_fps, az_deg = NaN)` — static factory; computes all trig pre-computation (sin/cos lat, sin/cos az, range/cross offsets) from geographic degrees; NaN lat → no Coriolis; NaN az → flat-fire drift only
+- `BCLIBC_Atmosphere::from_conditions(t_c, p_hpa, alt_ft, humidity = 0.0)` — static factory; CIPM-2007 moist-air density, Rankine Mach formula matching Python `machF()` exactly; p_hpa ≤ 0 → vacuum (zero density, no drag)
+- `BCLIBC_cStandardDensityMetric` constant (1.2250 kg/m³) — ICAO sea-level standard density used to normalise CIPM-2007 output
+- `BCLIBC_Shot` struct — user-facing shot descriptor (natural units, no pre-computation, non-owning pointers for drag table and winds arrays); `to_shot_props()` assembles engine-ready `BCLIBC_ShotProps` performing all conversions in one place: cant cos/sin, atmosphere, Coriolis, PCHIP drag curve, wind sock
+- `BCLIBCFFI_Shot` C struct in `bclibc_ffi.h` — C-compatible mirror of `BCLIBC_Shot` for Dart FFI / other C consumers; takes raw user-facing units (`temp_c`, `pressure_hpa`, `latitude_deg`, `azimuth_deg`) and two parallel `mach_data`/`cd_data` arrays (same layout as `BCLIBC_Shot`); `pressure_hpa == 0` → vacuum
+- `BCLIBCFFI_find_apex_shot`, `BCLIBCFFI_find_max_range_shot`, `BCLIBCFFI_find_zero_angle_shot`, `BCLIBCFFI_integrate_shot`, `BCLIBCFFI_integrate_at_shot` — FFI entry points accepting `BCLIBCFFI_Shot`; all physics conversion delegated to `BCLIBC_Shot::to_shot_props()` in C++
+
+### Changed (**breaking** — requires new minor version for all C FFI consumers)
+- `bclibc_ffi.h`: all C struct and enum types renamed from `BC*` to `BCLIBCFFI_*` to be consistent with the `BCLIBCFFI_` function prefix:
+  - `BCConfig` → `BCLIBCFFI_Config`
+  - `BCAtmosphere` → `BCLIBCFFI_Atmosphere`
+  - `BCCoriolis` → `BCLIBCFFI_Coriolis`
+  - `BCWind` → `BCLIBCFFI_Wind`
+  - `BCDragPoint` → `BCLIBCFFI_DragPoint`
+  - `BCShotProps` → `BCLIBCFFI_ShotProps`
+  - `BCShot` → `BCLIBCFFI_Shot` (also changed `drag_table: BCDragPoint*` to separate `mach_data/cd_data: const double*` arrays, matching `BCLIBC_Shot` layout)
+  - `BCTrajFlag` enum → `BCLIBCFFI_TrajFlag`; values `BC_TRAJ_FLAG_*` → `BCLIBCFFI_TRAJ_FLAG_*`
+  - `BCTerminationReason` enum → `BCLIBCFFI_TerminationReason`; values `BC_TERM_*` → `BCLIBCFFI_TERM_*`
+  - `BCBaseTrajInterpKey` enum → `BCLIBCFFI_BaseTrajInterpKey`; values `BC_INTERP_KEY_*` → `BCLIBCFFI_INTERP_KEY_*`
+  - `BCIntegrationMethod` enum → `BCLIBCFFI_IntegrationMethod`; values `BC_INTEGRATION_*` → `BCLIBCFFI_INTEGRATION_*`
+  - `BCTrajectoryRequest` → `BCLIBCFFI_TrajectoryRequest`
+  - `BCBaseTrajData` → `BCLIBCFFI_BaseTrajData`
+  - `BCTrajectoryData` → `BCLIBCFFI_TrajectoryData`
+  - `BCMaxRangeResult` → `BCLIBCFFI_MaxRangeResult`
+  - `BCInterception` → `BCLIBCFFI_Interception`
+  - `BCLIBCFFIStatus` enum → `BCLIBCFFI_Status` (consistent with `BCLIBCFFI_<Name>` pattern)
+  - `BCLIBCFFIError` struct → `BCLIBCFFI_Error`
+- C++ internal types (`BCLIBC_TRAJ_FLAG_*`, `BCLIBC_Shot`, `BCLIBC_ShotProps`, etc. in `base_types.hpp`) are **unchanged** — this rename affects only the C FFI layer (`bclibc_ffi.h`)
+
 ## [1.0.5] - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-26
+
 ### Added
 - `BCLIBC_Coriolis::from_lat_az(lat_deg, muzzle_velocity_fps, az_deg = NaN)` — static factory; computes all trig pre-computation (sin/cos lat, sin/cos az, range/cross offsets) from geographic degrees; NaN lat → no Coriolis; NaN az → flat-fire drift only
 - `BCLIBC_Atmosphere::from_conditions(t_c, p_hpa, alt_ft, humidity = 0.0)` — static factory; CIPM-2007 moist-air density, Rankine Mach formula matching Python `machF()` exactly; p_hpa ≤ 0 → vacuum (zero density, no drag)
@@ -87,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ballistics-lab/bclibc/compare/v1.0.5...HEAD
+[Unreleased]: https://github.com/ballistics-lab/bclibc/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/ballistics-lab/bclibc/compare/v1.0.5...v1.1.0
 [1.0.5]: https://github.com/ballistics-lab/bclibc/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/ballistics-lab/bclibc/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/ballistics-lab/bclibc/compare/v1.0.2...v1.0.3

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ cmake --build build --config Release
 
 The public C API is declared in `include/bclibc/ffi/bclibc_ffi.h`. All symbols are prefixed with `BCLIBCFFI_`.
 
+**`BCLIBCFFI_ShotProps`-based (pre-computed physics, legacy path):**
+
 | Function | Description |
 |---|---|
 | `BCLIBCFFI_get_version()` | Library version string |
@@ -95,6 +97,30 @@ The public C API is declared in `include/bclibc/ffi/bclibc_ffi.h`. All symbols a
 | `BCLIBCFFI_get_correction()` | Angular correction for offset at distance |
 | `BCLIBCFFI_calculate_energy()` | Kinetic energy (ft-lb) |
 | `BCLIBCFFI_calculate_ogw()` | Optimal Game Weight |
+
+**`BCLIBCFFI_Shot`-based (natural units, preferred — all physics conversion in C++):**
+
+| Function | Description |
+|---|---|
+| `BCLIBCFFI_find_apex_shot()` | Highest point of trajectory |
+| `BCLIBCFFI_find_max_range_shot()` | Maximum range and angle |
+| `BCLIBCFFI_find_zero_angle_shot()` | Barrel elevation to zero at distance |
+| `BCLIBCFFI_integrate_shot()` | Full trajectory, filtered by step/flags |
+| `BCLIBCFFI_integrate_at_shot()` | Single interpolated point at key value |
+
+`BCLIBCFFI_Shot` accepts raw user-facing units (`temp_c`, `pressure_hpa`, `latitude_deg`, `azimuth_deg`, parallel `mach_data`/`cd_data` arrays). All atmosphere density, Coriolis trig, PCHIP drag curve, and cant pre-computation are performed inside C++ by `BCLIBC_Shot::to_shot_props()`.
+
+**Key types:**
+
+| Type | Description |
+|---|---|
+| `BCLIBCFFI_Shot` | Preferred shot input (natural units) |
+| `BCLIBCFFI_ShotProps` | Legacy shot input (pre-computed physics) |
+| `BCLIBCFFI_TrajectoryData` | One filtered trajectory record |
+| `BCLIBCFFI_TrajectoryRequest` | Step / range / filter config for `integrate` |
+| `BCLIBCFFI_Interception` | Single interpolated point from `integrate_at` |
+| `BCLIBCFFI_MaxRangeResult` | Max range + angle from `find_max_range` |
+| `BCLIBCFFI_Error` | Error code + message + typed extra fields |
 
 ### Symbol visibility
 

--- a/include/bclibc/base_types.hpp
+++ b/include/bclibc/base_types.hpp
@@ -2,6 +2,7 @@
 #define BCLIBC_BASE_TYPES_HPP
 
 #include <cstddef>
+#include <limits>
 #include <vector>
 #include "v3d.hpp"
 
@@ -60,6 +61,10 @@ namespace bclibc
      * @brief Earth's angular velocity in radians per second.
      */
     extern const double BCLIBC_cEarthAngularVelocityRadS;
+    /**
+     * @brief ICAO standard sea-level air density (kg/m³). Used to normalise CIPM-2007 density to a ratio.
+     */
+    extern const double BCLIBC_cStandardDensityMetric;
 
     enum class BCLIBC_TerminationReason
     {
@@ -147,6 +152,24 @@ namespace bclibc
             double cLowestTempC);
 
         /**
+         * @brief Factory: construct BCLIBC_Atmosphere from user-facing conditions using CIPM-2007.
+         *
+         * Computes air density via the CIPM-2007 moist-air equation, normalises to
+         * BCLIBC_cStandardDensityMetric (1.2250 kg/m³), and derives Mach 1 in fps.
+         * Mirrors Python's Atmo.calculate_air_density() — the authoritative reference.
+         *
+         * @param t_c       Dry-bulb temperature in degrees Celsius.
+         * @param p_hpa     Atmospheric pressure in hectopascals (hPa).
+         * @param alt_ft    Base altitude in feet (stored as _a0; used by altitude update).
+         * @param humidity  Relative humidity: fraction [0..1] or percent [0..100]. Default 0.
+         */
+        static BCLIBC_Atmosphere from_conditions(
+            double t_c,
+            double p_hpa,
+            double alt_ft,
+            double humidity = 0.0);
+
+        /**
          * @brief Updates the density ratio and speed of sound (Mach 1) for a given altitude.
          *
          * This function calculates the new atmospheric pressure, temperature, and resulting
@@ -191,6 +214,24 @@ namespace bclibc
             double cross_north,
             int flat_fire_only,
             double muzzle_velocity_fps);
+
+        /**
+         * @brief Factory: construct BCLIBC_Coriolis from geographic inputs.
+         *
+         * Mirrors the Python reference implementation `Coriolis.create()`.
+         *
+         * - lat_deg == NaN  → all fields zero, flat_fire_only=1 (no Coriolis effect)
+         * - az_deg  == NaN  → flat-fire only (sin/cos lat computed, azimuth zeroed)
+         * - both provided   → full 3D Coriolis (all trig fields computed)
+         *
+         * @param lat_deg            Geographic latitude in degrees (-90…+90). NaN disables Coriolis.
+         * @param muzzle_velocity_fps Muzzle velocity in feet per second.
+         * @param az_deg             Shot azimuth in degrees (0=North, 90=East). Default NaN → flat-fire only.
+         */
+        static BCLIBC_Coriolis from_lat_az(
+            double lat_deg,
+            double muzzle_velocity_fps,
+            double az_deg = std::numeric_limits<double>::quiet_NaN());
 
         void flat_fire_offsets(
             double time,
@@ -406,6 +447,71 @@ namespace bclibc
      * Takes vectors X and Y, returns BCLIBC_Curve.
      */
     BCLIBC_Curve build_pchip_curve_from_arrays(const std::vector<double> &x, const std::vector<double> &y);
+
+    /**
+     * @brief User-facing shot descriptor — all fields in natural units, no pre-computation.
+     *
+     * Wrappers (Python/Cython, Dart FFI, WASM) fill this struct from their domain objects
+     * and call to_shot_props() to obtain the engine-ready BCLIBC_ShotProps.  All physics
+     * conversions (cant trig, CIPM-2007 atmosphere, Coriolis trig, PCHIP drag curve) happen
+     * once, inside to_shot_props(), eliminating per-wrapper duplication.
+     *
+     * Lifetime note: mach_data, cd_data, and winds are non-owning pointers.  The caller must
+     * keep the backing arrays alive until to_shot_props() returns.
+     */
+    struct BCLIBC_Shot
+    {
+        // ammo
+        double bc;
+        double weight_grain;
+        double diameter_inch;
+        double length_inch;
+        double muzzle_velocity_fps;
+        double stability_coefficient;   ///< 0.0 → computed by engine on first step
+
+        // drag table — raw Mach/CD pairs; PCHIP built inside to_shot_props()
+        const double* mach_data;
+        const double* cd_data;
+        int           drag_table_size;
+
+        // weapon geometry
+        double sight_height_ft;
+        double twist_inch;             ///< positive = right-hand twist, negative = left-hand
+
+        // atmosphere (user-facing inputs, not pre-computed)
+        double temp_c;       ///< dry-bulb temperature in °C
+        double pressure_hpa; ///< atmospheric pressure in hPa; 0 → vacuum (zero drag)
+        double altitude_ft;  ///< base altitude in feet (used for density altitude adjustment)
+        double humidity;     ///< relative humidity: fraction [0..1] or percent [0..100]
+
+        // winds — non-owning array; wind_count == 0 → no wind
+        const BCLIBC_Wind* winds;
+        int                wind_count;
+
+        // aiming (all in radians)
+        double look_angle_rad;
+        double barrel_elevation_rad;
+        double barrel_azimuth_rad;
+        double cant_angle_rad;   ///< to_shot_props() computes cant_cosine/cant_sine internally
+
+        // Coriolis inputs (degrees; NaN disables)
+        double latitude_deg;   ///< geographic latitude [-90..+90]; NaN → no Coriolis effect
+        double azimuth_deg;    ///< shot azimuth [0..360); NaN → flat-fire drift only
+
+        double calc_step;      ///< integration step in feet
+
+        /**
+         * @brief Assemble engine-ready BCLIBC_ShotProps.
+         *
+         * Performs all physics/unit conversions:
+         *   - cant_cosine / cant_sine  from cant_angle_rad
+         *   - BCLIBC_Atmosphere        via BCLIBC_Atmosphere::from_conditions()  (CIPM-2007)
+         *   - BCLIBC_Coriolis          via BCLIBC_Coriolis::from_lat_az()
+         *   - BCLIBC_Curve / MachList  via build_pchip_curve_from_arrays()
+         *   - BCLIBC_WindSock          from the winds array
+         */
+        BCLIBC_ShotProps to_shot_props() const;
+    };
 
     /**
      * @brief Calculates the angular correction needed to hit a target.

--- a/include/bclibc/ffi/bclibc_ffi.h
+++ b/include/bclibc/ffi/bclibc_ffi.h
@@ -41,7 +41,7 @@ extern "C"
     // Error codes
     // ============================================================================
 
-    typedef enum BCLIBCFFIStatus
+    typedef enum BCLIBCFFI_Status
     {
         BCLIBCFFI_OK = 0,
         BCLIBCFFI_ERR_SOLVER_RUNTIME = 1,
@@ -49,71 +49,71 @@ extern "C"
         BCLIBCFFI_ERR_ZERO_FINDING = 3,
         BCLIBCFFI_ERR_INTERCEPTION = 4,
         BCLIBCFFI_ERR_GENERIC = 5,
-    } BCLIBCFFIStatus;
+    } BCLIBCFFI_Status;
 
     /** Error output struct – filled by every function on failure. */
-    typedef struct BCLIBCFFIError
+    typedef struct BCLIBCFFI_Error
     {
-        int32_t code;      /**< BCLIBCFFIStatus */
+        int32_t code;      /**< BCLIBCFFI_Status */
         char message[512]; /**< Null-terminated error message */
         /* Extra fields for typed errors */
         double f64_0;  /**< OutOfRange: requested_distance_ft / ZeroFinding: zero_finding_error */
         double f64_1;  /**< OutOfRange: max_range_ft          / ZeroFinding: last_barrel_elevation_rad */
         double f64_2;  /**< OutOfRange: look_angle_rad */
         int32_t i32_0; /**< ZeroFinding: iterations_count */
-    } BCLIBCFFIError;
+    } BCLIBCFFI_Error;
 
     // ============================================================================
     // Enums
     // ============================================================================
 
-    typedef enum BCTrajFlag
+    typedef enum BCLIBCFFI_TrajFlag
     {
-        BC_TRAJ_FLAG_NONE = 0,
-        BC_TRAJ_FLAG_ZERO_UP = 1,
-        BC_TRAJ_FLAG_ZERO_DOWN = 2,
-        BC_TRAJ_FLAG_ZERO = 3,
-        BC_TRAJ_FLAG_MACH = 4,
-        BC_TRAJ_FLAG_RANGE = 8,
-        BC_TRAJ_FLAG_APEX = 16,
-        BC_TRAJ_FLAG_ALL = 31,
-        BC_TRAJ_FLAG_MRT = 32,
-    } BCTrajFlag;
+        BCLIBCFFI_TRAJ_FLAG_NONE = 0,
+        BCLIBCFFI_TRAJ_FLAG_ZERO_UP = 1,
+        BCLIBCFFI_TRAJ_FLAG_ZERO_DOWN = 2,
+        BCLIBCFFI_TRAJ_FLAG_ZERO = 3,
+        BCLIBCFFI_TRAJ_FLAG_MACH = 4,
+        BCLIBCFFI_TRAJ_FLAG_RANGE = 8,
+        BCLIBCFFI_TRAJ_FLAG_APEX = 16,
+        BCLIBCFFI_TRAJ_FLAG_ALL = 31,
+        BCLIBCFFI_TRAJ_FLAG_MRT = 32,
+    } BCLIBCFFI_TrajFlag;
 
-    typedef enum BCTerminationReason
+    typedef enum BCLIBCFFI_TerminationReason
     {
-        BC_TERM_NO_TERMINATE = 0,
-        BC_TERM_TARGET_RANGE_REACHED = 1,
-        BC_TERM_MINIMUM_VELOCITY_REACHED = 2,
-        BC_TERM_MAXIMUM_DROP_REACHED = 3,
-        BC_TERM_MINIMUM_ALTITUDE_REACHED = 4,
-        BC_TERM_HANDLER_REQUESTED_STOP = 5,
-    } BCTerminationReason;
+        BCLIBCFFI_TERM_NO_TERMINATE = 0,
+        BCLIBCFFI_TERM_TARGET_RANGE_REACHED = 1,
+        BCLIBCFFI_TERM_MINIMUM_VELOCITY_REACHED = 2,
+        BCLIBCFFI_TERM_MAXIMUM_DROP_REACHED = 3,
+        BCLIBCFFI_TERM_MINIMUM_ALTITUDE_REACHED = 4,
+        BCLIBCFFI_TERM_HANDLER_REQUESTED_STOP = 5,
+    } BCLIBCFFI_TerminationReason;
 
     /** Interpolation key for BCLIBC_BaseTrajData fields. */
-    typedef enum BCBaseTrajInterpKey
+    typedef enum BCLIBCFFI_BaseTrajInterpKey
     {
-        BC_INTERP_KEY_TIME = 0,
-        BC_INTERP_KEY_MACH = 1,
-        BC_INTERP_KEY_POS_X = 2,
-        BC_INTERP_KEY_POS_Y = 3,
-        BC_INTERP_KEY_POS_Z = 4,
-        BC_INTERP_KEY_VEL_X = 5,
-        BC_INTERP_KEY_VEL_Y = 6,
-        BC_INTERP_KEY_VEL_Z = 7,
-    } BCBaseTrajInterpKey;
+        BCLIBCFFI_INTERP_KEY_TIME = 0,
+        BCLIBCFFI_INTERP_KEY_MACH = 1,
+        BCLIBCFFI_INTERP_KEY_POS_X = 2,
+        BCLIBCFFI_INTERP_KEY_POS_Y = 3,
+        BCLIBCFFI_INTERP_KEY_POS_Z = 4,
+        BCLIBCFFI_INTERP_KEY_VEL_X = 5,
+        BCLIBCFFI_INTERP_KEY_VEL_Y = 6,
+        BCLIBCFFI_INTERP_KEY_VEL_Z = 7,
+    } BCLIBCFFI_BaseTrajInterpKey;
 
-    typedef enum BCIntegrationMethod
+    typedef enum BCLIBCFFI_IntegrationMethod
     {
-        BC_INTEGRATION_RK4 = 0,
-        BC_INTEGRATION_EULER = 1,
-    } BCIntegrationMethod;
+        BCLIBCFFI_INTEGRATION_RK4 = 0,
+        BCLIBCFFI_INTEGRATION_EULER = 1,
+    } BCLIBCFFI_IntegrationMethod;
 
     // ============================================================================
     // Input structs
     // ============================================================================
 
-    typedef struct BCConfig
+    typedef struct BCLIBCFFI_Config
     {
         double cStepMultiplier;
         double cZeroFindingAccuracy;
@@ -122,9 +122,9 @@ extern "C"
         int32_t cMaxIterations;
         double cGravityConstant;
         double cMinimumAltitude;
-    } BCConfig;
+    } BCLIBCFFI_Config;
 
-    typedef struct BCAtmosphere
+    typedef struct BCLIBCFFI_Atmosphere
     {
         double t0;            /**< Temperature at base altitude (°F) */
         double a0;            /**< Base altitude (ft) */
@@ -132,9 +132,9 @@ extern "C"
         double mach;          /**< Speed of sound (fps) */
         double density_ratio; /**< Air density / standard density */
         double cLowestTempC;  /**< Lowest allowed temperature (°C) */
-    } BCAtmosphere;
+    } BCLIBCFFI_Atmosphere;
 
-    typedef struct BCCoriolis
+    typedef struct BCLIBCFFI_Coriolis
     {
         double sin_lat;
         double cos_lat;
@@ -146,24 +146,24 @@ extern "C"
         double cross_north;
         int32_t flat_fire_only; /**< Non-zero = flat-fire approximation */
         double muzzle_velocity_fps;
-    } BCCoriolis;
+    } BCLIBCFFI_Coriolis;
 
-    typedef struct BCWind
+    typedef struct BCLIBCFFI_Wind
     {
         double velocity_fps;
         double direction_from_rad;
         double until_distance_ft;
         double max_distance_ft; /**< Sentinel for last segment (use BCLIBC_cMaxWindDistanceFeet) */
-    } BCWind;
+    } BCLIBCFFI_Wind;
 
-    typedef struct BCDragPoint
+    typedef struct BCLIBCFFI_DragPoint
     {
         double Mach;
         double CD;
-    } BCDragPoint;
+    } BCLIBCFFI_DragPoint;
 
     /** Flat shot properties passed to every engine function. */
-    typedef struct BCShotProps
+    typedef struct BCLIBCFFI_ShotProps
     {
         double bc;
         double look_angle_rad;
@@ -178,34 +178,88 @@ extern "C"
         double alt0_ft;
         double muzzle_velocity_fps;
 
-        BCAtmosphere atmo;
-        BCCoriolis coriolis;
-        BCConfig config;
+        BCLIBCFFI_Atmosphere atmo;
+        BCLIBCFFI_Coriolis coriolis;
+        BCLIBCFFI_Config config;
 
-        BCIntegrationMethod method;
+        BCLIBCFFI_IntegrationMethod method;
 
         /** Drag table – pointer must remain valid for the duration of the call. */
-        const BCDragPoint *drag_table;
+        const BCLIBCFFI_DragPoint *drag_table;
         int32_t drag_table_count;
 
         /** Wind list – pointer must remain valid for the duration of the call. */
-        const BCWind *winds;
+        const BCLIBCFFI_Wind *winds;
         int32_t wind_count;
-    } BCShotProps;
+    } BCLIBCFFI_ShotProps;
 
-    typedef struct BCTrajectoryRequest
+    /**
+     * User-facing shot descriptor in natural units.
+     *
+     * Preferred input for BCLIBCFFI_*_shot() functions.  All physics conversions
+     * (CIPM-2007 atmosphere density, Coriolis trig, PCHIP drag curve, cant sin/cos)
+     * are performed inside C++ by BCLIBC_Shot::to_shot_props().
+     *
+     * latitude_deg / azimuth_deg: pass NaN to disable Coriolis / flat-fire-only.
+     * pressure_hpa == 0          : vacuum (zero drag).
+     *
+     * All pointers must remain valid for the duration of the call.
+     * Drag table is passed as two parallel arrays (mach_data / cd_data) matching
+     * the BCLIBC_Shot layout — no interleaved struct needed.
+     */
+    typedef struct BCLIBCFFI_Shot
+    {
+        double bc;
+        double weight_grain;
+        double diameter_inch;
+        double length_inch;
+        double muzzle_velocity_fps;
+
+        double sight_height_ft;
+        double twist_inch;
+
+        /* Atmosphere – raw user-facing units, not pre-computed */
+        double temp_c;
+        double pressure_hpa; /**< 0 = vacuum */
+        double altitude_ft;
+        double humidity;     /**< 0.0 – 1.0 */
+
+        /** Parallel Mach / CD arrays – must remain valid for the duration of the call. */
+        const double *mach_data;
+        const double *cd_data;
+        int32_t drag_table_size;
+
+        /** Wind list – must remain valid for the duration of the call. */
+        const BCLIBCFFI_Wind *winds;
+        int32_t wind_count;
+
+        /* Aiming */
+        double look_angle_rad;
+        double barrel_elevation_rad;
+        double barrel_azimuth_rad;
+        double cant_angle_rad;
+
+        /* Coriolis – raw geographic degrees; NaN disables Coriolis / enables flat-fire-only */
+        double latitude_deg;
+        double azimuth_deg;
+
+        BCLIBCFFI_Config config;
+        BCLIBCFFI_IntegrationMethod method;
+    } BCLIBCFFI_Shot;
+
+    typedef struct BCLIBCFFI_TrajectoryRequest
     {
         double range_limit_ft;
         double range_step_ft;
         double time_step;
-        int32_t filter_flags; /**< BCTrajFlag bitmask */
-    } BCTrajectoryRequest;
+        int32_t filter_flags; /**< BCLIBCFFI_TrajFlag bitmask */
+    } BCLIBCFFI_TrajectoryRequest;
 
     // ============================================================================
     // Output structs
     // ============================================================================
 
-    typedef struct BCBaseTrajData
+    typedef struct BCLIBCFFI_BaseTrajData
     {
         double time;
         double px; /**< Position x (downrange, ft) */
@@ -215,9 +269,9 @@ extern "C"
         double vy; /**< Velocity y (fps) */
         double vz; /**< Velocity z (fps) */
         double mach;
-    } BCBaseTrajData;
+    } BCLIBCFFI_BaseTrajData;
 
-    typedef struct BCTrajectoryData
+    typedef struct BCLIBCFFI_TrajectoryData
     {
         double time;
         double distance_ft;
@@ -234,20 +288,20 @@ extern "C"
         double drag;
         double energy_ft_lb;
         double ogw_lb;
-        int32_t flag; /**< BCTrajFlag */
-    } BCTrajectoryData;
+        int32_t flag; /**< BCLIBCFFI_TrajFlag */
+    } BCLIBCFFI_TrajectoryData;
 
-    typedef struct BCMaxRangeResult
+    typedef struct BCLIBCFFI_MaxRangeResult
     {
         double max_range_ft;
         double angle_at_max_rad;
-    } BCMaxRangeResult;
+    } BCLIBCFFI_MaxRangeResult;
 
-    typedef struct BCInterception
+    typedef struct BCLIBCFFI_Interception
     {
-        BCBaseTrajData raw_data;
-        BCTrajectoryData full_data;
-    } BCInterception;
+        BCLIBCFFI_BaseTrajData raw_data;
+        BCLIBCFFI_TrajectoryData full_data;
+    } BCLIBCFFI_Interception;
 
     // ============================================================================
     // Core functions
@@ -258,9 +312,9 @@ extern "C"
      * @return BCLIBCFFI_OK on success, error code otherwise (fills *err).
      */
     BCLIBC_API int32_t BCLIBCFFI_find_apex(
-        const BCShotProps *props,
-        BCTrajectoryData *out,
-        BCLIBCFFIError *err);
+        const BCLIBCFFI_ShotProps *props,
+        BCLIBCFFI_TrajectoryData *out,
+        BCLIBCFFI_Error *err);
 
     /**
      * Find the maximum range and corresponding angle.
@@ -268,11 +322,11 @@ extern "C"
      * @param high_angle_deg  Upper search bound (degrees).
      */
     BCLIBC_API int32_t BCLIBCFFI_find_max_range(
-        const BCShotProps *props,
+        const BCLIBCFFI_ShotProps *props,
         double low_angle_deg,
         double high_angle_deg,
-        BCMaxRangeResult *out,
-        BCLIBCFFIError *err);
+        BCLIBCFFI_MaxRangeResult *out,
+        BCLIBCFFI_Error *err);
 
     /**
      * Find the barrel elevation angle to zero at the given distance.
@@ -280,40 +334,81 @@ extern "C"
      * @param out_angle_rad   Output: barrel elevation (radians).
      */
     BCLIBC_API int32_t BCLIBCFFI_find_zero_angle(
-        const BCShotProps *props,
+        const BCLIBCFFI_ShotProps *props,
         double distance_ft,
         double *out_angle_rad,
-        BCLIBCFFIError *err);
+        BCLIBCFFI_Error *err);
 
     /**
      * Integrate trajectory and return filtered records.
      *
-     * On success *out_records points to a heap-allocated BCTrajectoryData array
+     * On success *out_records points to a heap-allocated BCLIBCFFI_TrajectoryData array
      * of length *out_count.  Call BCLIBCFFI_free_trajectory() to release it.
      */
     BCLIBC_API int32_t BCLIBCFFI_integrate(
-        const BCShotProps *props,
-        const BCTrajectoryRequest *request,
-        BCTrajectoryData **out_records,
+        const BCLIBCFFI_ShotProps *props,
+        const BCLIBCFFI_TrajectoryRequest *request,
+        BCLIBCFFI_TrajectoryData **out_records,
         int32_t *out_count,
-        int32_t *out_reason, /**< BCTerminationReason */
-        BCLIBCFFIError *err);
+        int32_t *out_reason, /**< BCLIBCFFI_TerminationReason */
+        BCLIBCFFI_Error *err);
 
     /** Free a trajectory array allocated by BCLIBCFFI_integrate(). */
-    BCLIBC_API void BCLIBCFFI_free_trajectory(BCTrajectoryData *records);
+    BCLIBC_API void BCLIBCFFI_free_trajectory(BCLIBCFFI_TrajectoryData *records);
 
     /**
      * Integrate and interpolate the single point where a key field reaches
      * the target value.
-     * @param key          BCBaseTrajInterpKey
+     * @param key          BCLIBCFFI_BaseTrajInterpKey
      * @param target_value Value the key field must reach.
      */
     BCLIBC_API int32_t BCLIBCFFI_integrate_at(
-        const BCShotProps *props,
+        const BCLIBCFFI_ShotProps *props,
         int32_t key,
         double target_value,
-        BCInterception *out,
-        BCLIBCFFIError *err);
+        BCLIBCFFI_Interception *out,
+        BCLIBCFFI_Error *err);
+
+    // ============================================================================
+    // Core functions (BCLIBCFFI_Shot – preferred, all physics conversion in C++)
+    // ============================================================================
+
+    /**
+     * Find the apex of the trajectory.
+     * All physics/unit conversion is performed inside C++ via BCLIBCFFI_Shot::to_shot_props().
+     */
+    BCLIBC_API int32_t BCLIBCFFI_find_apex_shot(
+        const BCLIBCFFI_Shot *shot,
+        BCLIBCFFI_TrajectoryData *out,
+        BCLIBCFFI_Error *err);
+
+    BCLIBC_API int32_t BCLIBCFFI_find_max_range_shot(
+        const BCLIBCFFI_Shot *shot,
+        double low_angle_deg,
+        double high_angle_deg,
+        BCLIBCFFI_MaxRangeResult *out,
+        BCLIBCFFI_Error *err);
+
+    BCLIBC_API int32_t BCLIBCFFI_find_zero_angle_shot(
+        const BCLIBCFFI_Shot *shot,
+        double distance_ft,
+        double *out_angle_rad,
+        BCLIBCFFI_Error *err);
+
+    BCLIBC_API int32_t BCLIBCFFI_integrate_shot(
+        const BCLIBCFFI_Shot *shot,
+        const BCLIBCFFI_TrajectoryRequest *request,
+        BCLIBCFFI_TrajectoryData **out_records,
+        int32_t *out_count,
+        int32_t *out_reason, /**< BCLIBCFFI_TerminationReason */
+        BCLIBCFFI_Error *err);
+
+    BCLIBC_API int32_t BCLIBCFFI_integrate_at_shot(
+        const BCLIBCFFI_Shot *shot,
+        int32_t key,
+        double target_value,
+        BCLIBCFFI_Interception *out,
+        BCLIBCFFI_Error *err);
 
     // ============================================================================
     // Utility functions

--- a/src/base_types.cpp
+++ b/src/base_types.cpp
@@ -13,6 +13,7 @@ namespace bclibc
      * @brief Earth's angular velocity in radians per second.
      */
     const double BCLIBC_cEarthAngularVelocityRadS = 7.2921159e-5;
+    const double BCLIBC_cStandardDensityMetric = 1.2250; // kg/m³, ICAO sea-level standard
     /**
      * @brief Conversion factor from degrees Fahrenheit to degrees Rankine.
      */
@@ -501,6 +502,60 @@ namespace bclibc
         return total_size;
     }
 
+    /**
+     * @brief Assemble engine-ready BCLIBC_ShotProps from user-facing BCLIBC_Shot inputs.
+     *
+     * All physics/unit conversions happen here — once, in C++ — eliminating per-wrapper
+     * duplication across Python/Cython, Dart FFI, and WASM.
+     */
+    BCLIBC_ShotProps BCLIBC_Shot::to_shot_props() const
+    {
+        // Atmosphere: CIPM-2007 density + Rankine Mach formula
+        BCLIBC_Atmosphere atmo = BCLIBC_Atmosphere::from_conditions(
+            temp_c, pressure_hpa, altitude_ft, humidity);
+
+        // Coriolis: full trig pre-computation from geographic lat/az (degrees)
+        BCLIBC_Coriolis coriolis = BCLIBC_Coriolis::from_lat_az(
+            latitude_deg, muzzle_velocity_fps, azimuth_deg);
+
+        // Wind sock: copy wind array into owned vector
+        BCLIBC_WindSock wind_sock;
+        if (winds != nullptr && wind_count > 0)
+        {
+            std::vector<BCLIBC_Wind> winds_vec(winds, winds + wind_count);
+            wind_sock = BCLIBC_WindSock(std::move(winds_vec));
+        }
+
+        // Drag curve: build PCHIP from raw Mach/CD arrays
+        std::vector<double> mach_v(mach_data, mach_data + drag_table_size);
+        std::vector<double> cd_v(cd_data, cd_data + drag_table_size);
+        BCLIBC_Curve curve = build_pchip_curve_from_arrays(mach_v, cd_v);
+        BCLIBC_MachList mach_list = BCLIBC_MachList(mach_v.begin(), mach_v.end());
+
+        return BCLIBC_ShotProps(
+            bc,
+            look_angle_rad,
+            twist_inch,
+            length_inch,
+            diameter_inch,
+            weight_grain,
+            barrel_elevation_rad,
+            barrel_azimuth_rad,
+            sight_height_ft,
+            std::cos(cant_angle_rad), // cant_cosine
+            std::sin(cant_angle_rad), // cant_sine
+            altitude_ft,              // alt0
+            calc_step,
+            muzzle_velocity_fps,
+            stability_coefficient,
+            std::move(curve),
+            std::move(mach_list),
+            std::move(atmo),
+            std::move(coriolis),
+            std::move(wind_sock),
+            BCLIBC_TRAJ_FLAG_NONE);
+    }
+
     BCLIBC_Atmosphere::BCLIBC_Atmosphere(
         double _t0,
         double _a0,
@@ -514,6 +569,55 @@ namespace bclibc
           _mach(_mach),
           density_ratio(density_ratio),
           cLowestTempC(cLowestTempC) {};
+
+    /**
+     * @brief Factory: construct BCLIBC_Atmosphere from user-facing conditions using CIPM-2007.
+     *
+     * Mirrors Python's Atmo.calculate_air_density() — the authoritative reference implementation.
+     * Source: CIPM-2007 (https://www.nist.gov/system/files/documents/calibrations/CIPM-2007.pdf)
+     */
+    BCLIBC_Atmosphere BCLIBC_Atmosphere::from_conditions(
+        double t_c, double p_hpa, double alt_ft, double humidity)
+    {
+        static const double kLowestTempC = (BCLIBC_cLowestTempF - 32.0) * 5.0 / 9.0;
+
+        const double T_K = t_c + BCLIBC_cDegreesCtoK;
+        // Rankine formula matches Python's Atmo.machF() exactly (Rankine = Kelvin * 9/5)
+        const double mach_fps = std::sqrt(T_K * (9.0 / 5.0)) * BCLIBC_cSpeedOfSoundImperial;
+
+        // Zero pressure → vacuum (zero density, no drag). Mirrors Python Vacuum behaviour.
+        if (p_hpa <= 0.0)
+            return BCLIBC_Atmosphere(t_c, alt_ft, p_hpa, mach_fps, 0.0, kLowestTempC);
+
+        // CIPM-2007 molar masses and universal gas constant
+        static const double R = 8.314472;      // J/(mol·K)
+        static const double M_a = 28.96546e-3; // kg/mol — dry air
+        static const double M_v = 18.01528e-3; // kg/mol — water vapour
+
+        const double p = p_hpa * 100.0; // hPa → Pa
+
+        // Normalize humidity to fraction [0..1], matching Python Atmo behaviour
+        double rh = (humidity > 1.0) ? humidity / 100.0 : humidity;
+        rh = std::fmax(0.0, std::fmin(1.0, rh));
+
+        // Saturation vapour pressure (Pa) — CIPM-2007 eq. (A1.1), T in Kelvin
+        const double p_sv = std::exp(
+            1.2378847e-5 * T_K * T_K - 1.9121316e-2 * T_K + 33.93711047 - 6.3431645e3 / T_K);
+
+        // Enhancement factor — p in Pa, t in Celsius
+        const double f = 1.00062 + 3.14e-8 * p + 5.6e-7 * t_c * t_c;
+
+        // Mole fraction of water vapour
+        const double x_v = (rh * f * p_sv) / p;
+
+        // Compressibility factor Z — t_c used for the t_l (= T_K - 273.15) terms
+        const double Z = 1.0 - (p / T_K) * (1.58123e-6 + (-2.9331e-8) * t_c + 1.1043e-10 * t_c * t_c + (5.707e-6 + (-2.051e-8) * t_c) * x_v + (1.9898e-4 + (-2.376e-6) * t_c) * x_v * x_v) + (p / T_K) * (p / T_K) * (1.83e-11 + (-0.765e-8) * x_v * x_v);
+
+        const double density = (p * M_a) / (Z * R * T_K) * (1.0 - x_v * (1.0 - M_v / M_a));
+        const double density_ratio = density / BCLIBC_cStandardDensityMetric;
+
+        return BCLIBC_Atmosphere(t_c, alt_ft, p_hpa, mach_fps, density_ratio, kLowestTempC);
+    }
 
     /**
      * @brief Updates the density ratio and speed of sound (Mach 1) for a given altitude.
@@ -784,6 +888,42 @@ namespace bclibc
           cross_north(cross_north),
           flat_fire_only(flat_fire_only),
           muzzle_velocity_fps(muzzle_velocity_fps) {};
+
+    BCLIBC_Coriolis BCLIBC_Coriolis::from_lat_az(
+        double lat_deg,
+        double muzzle_velocity_fps,
+        double az_deg)
+    {
+        // No latitude supplied → no Coriolis effect (mirrors Python Coriolis.create() returning None)
+        if (std::isnan(lat_deg))
+        {
+            return BCLIBC_Coriolis(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, muzzle_velocity_fps);
+        }
+
+        static const double kDegToRad = 0.017453292519943295; // pi / 180
+        const double lat_rad = lat_deg * kDegToRad;
+        const double sin_lat = std::sin(lat_rad);
+        const double cos_lat = std::cos(lat_rad);
+
+        // No azimuth → flat-fire only mode (horizontal Coriolis drift only)
+        if (std::isnan(az_deg))
+        {
+            return BCLIBC_Coriolis(sin_lat, cos_lat, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1, muzzle_velocity_fps);
+        }
+
+        // Full 3D Coriolis
+        const double az_rad = az_deg * kDegToRad;
+        const double sin_az = std::sin(az_rad);
+        const double cos_az = std::cos(az_rad);
+
+        return BCLIBC_Coriolis(
+            sin_lat, cos_lat, sin_az, cos_az,
+            sin_az,  // range_east
+            cos_az,  // range_north
+            cos_az,  // cross_east
+            -sin_az, // cross_north
+            0, muzzle_velocity_fps);
+    }
 
     void BCLIBC_Coriolis::flat_fire_offsets(
         double time,

--- a/src/ffi/bclibc_ffi.cpp
+++ b/src/ffi/bclibc_ffi.cpp
@@ -4,7 +4,7 @@
  * Thin C++ wrapper that implements the bclibc_ffi.h C API.
  * Mirrors the structure of the WASM bindings (wasm/bindings.cpp):
  *   - PCHIP curve building from a flat drag table
- *   - Engine initialisation from BCShotProps
+ *   - Engine initialisation from BCLIBCFFI_ShotProps
  *   - Exception → error-code conversion
  */
 
@@ -33,7 +33,7 @@ using namespace bclibc;
 static constexpr double APEX_IS_MAX_RANGE_RADIANS = 0.0003;
 static constexpr double ALLOWED_ZERO_ERROR_FEET = 1e-2;
 
-static BCLIBC_Curve buildCurve(const BCDragPoint *dt, int n)
+static BCLIBC_Curve buildCurve(const BCLIBCFFI_DragPoint *dt, int n)
 {
     if (n < 2)
         throw std::invalid_argument("Drag table requires at least 2 points");
@@ -50,7 +50,7 @@ static BCLIBC_Curve buildCurve(const BCDragPoint *dt, int n)
     return build_pchip_curve_from_arrays(x, y);
 }
 
-static BCLIBC_MachList buildMachList(const BCDragPoint *dt, int n)
+static BCLIBC_MachList buildMachList(const BCLIBCFFI_DragPoint *dt, int n)
 {
     BCLIBC_MachList list;
     list.reserve(static_cast<size_t>(n));
@@ -63,7 +63,7 @@ static BCLIBC_MachList buildMachList(const BCDragPoint *dt, int n)
 // Error helpers
 // ============================================================================
 
-static void clearError(BCLIBCFFIError *e)
+static void clearError(BCLIBCFFI_Error *e)
 {
     if (!e)
         return;
@@ -73,7 +73,7 @@ static void clearError(BCLIBCFFIError *e)
     e->i32_0 = 0;
 }
 
-static void setError(BCLIBCFFIError *e, BCLIBCFFIStatus code, const char *msg)
+static void setError(BCLIBCFFI_Error *e, BCLIBCFFI_Status code, const char *msg)
 {
     if (!e)
         return;
@@ -86,18 +86,18 @@ static void setError(BCLIBCFFIError *e, BCLIBCFFIStatus code, const char *msg)
 // Engine initialisation (mirrors WASM initEngine + shotPropsFromVal)
 // ============================================================================
 
-static double calcStep(BCIntegrationMethod m, double multiplier)
+static double calcStep(BCLIBCFFI_IntegrationMethod m, double multiplier)
 {
-    return (m == BC_INTEGRATION_RK4 ? 0.0025 : 0.5) * multiplier;
+    return (m == BCLIBCFFI_INTEGRATION_RK4 ? 0.0025 : 0.5) * multiplier;
 }
 
-static BCLIBC_IntegrateCallable selectIntegrateFunc(BCIntegrationMethod m)
+static BCLIBC_IntegrateCallable selectIntegrateFunc(BCLIBCFFI_IntegrationMethod m)
 {
-    return (m == BC_INTEGRATION_RK4) ? BCLIBC_IntegrateCallable(BCLIBC_integrateRK4)
-                                     : BCLIBC_IntegrateCallable(BCLIBC_integrateEULER);
+    return (m == BCLIBCFFI_INTEGRATION_RK4) ? BCLIBC_IntegrateCallable(BCLIBC_integrateRK4)
+                                            : BCLIBC_IntegrateCallable(BCLIBC_integrateEULER);
 }
 
-static void initEngine(BCLIBC_BaseEngine &eng, const BCShotProps *p)
+static void initEngine(BCLIBC_BaseEngine &eng, const BCLIBCFFI_ShotProps *p)
 {
     BCLIBC_Config config(
         p->config.cStepMultiplier,
@@ -159,11 +159,65 @@ static void initEngine(BCLIBC_BaseEngine &eng, const BCShotProps *p)
     eng.gravity_vector = BCLIBC_V3dT(0.0, config.cGravityConstant, 0.0);
 }
 
+// Builds and initialises the engine from a BCLIBCFFI_Shot (user-facing natural units).
+// mach_data/cd_data passed directly — same layout as BCLIBC_Shot, no copy needed.
+// Winds are copied to BCLIBC_Wind; lifetime covers the to_shot_props() call.
+static void initEngineFromShot(BCLIBC_BaseEngine &eng, const BCLIBCFFI_Shot *s)
+{
+    // Copy BCLIBCFFI_Wind → BCLIBC_Wind; lifetime covers to_shot_props() call.
+    std::vector<BCLIBC_Wind> winds_v;
+    winds_v.reserve(static_cast<size_t>(s->wind_count));
+    for (int i = 0; i < s->wind_count; ++i)
+        winds_v.emplace_back(
+            s->winds[i].velocity_fps,
+            s->winds[i].direction_from_rad,
+            s->winds[i].until_distance_ft,
+            s->winds[i].max_distance_ft);
+
+    BCLIBC_Shot shot;
+    shot.bc = s->bc;
+    shot.weight_grain = s->weight_grain;
+    shot.diameter_inch = s->diameter_inch;
+    shot.length_inch = s->length_inch;
+    shot.muzzle_velocity_fps = s->muzzle_velocity_fps;
+    shot.stability_coefficient = 0.0;
+    shot.sight_height_ft = s->sight_height_ft;
+    shot.twist_inch = s->twist_inch;
+    shot.temp_c = s->temp_c;
+    shot.pressure_hpa = s->pressure_hpa;
+    shot.altitude_ft = s->altitude_ft;
+    shot.humidity = s->humidity;
+    shot.mach_data = s->mach_data;
+    shot.cd_data = s->cd_data;
+    shot.drag_table_size = s->drag_table_size;
+    shot.winds = winds_v.empty() ? nullptr : winds_v.data();
+    shot.wind_count = s->wind_count;
+    shot.look_angle_rad = s->look_angle_rad;
+    shot.barrel_elevation_rad = s->barrel_elevation_rad;
+    shot.barrel_azimuth_rad = s->barrel_azimuth_rad;
+    shot.cant_angle_rad = s->cant_angle_rad;
+    shot.latitude_deg = s->latitude_deg;
+    shot.azimuth_deg = s->azimuth_deg;
+    shot.calc_step = calcStep(s->method, s->config.cStepMultiplier);
+
+    eng.shot = shot.to_shot_props();
+    eng.integrate_func = selectIntegrateFunc(s->method);
+    eng.config = BCLIBC_Config(
+        s->config.cStepMultiplier,
+        s->config.cZeroFindingAccuracy,
+        s->config.cMinimumVelocity,
+        s->config.cMaximumDrop,
+        s->config.cMaxIterations,
+        s->config.cGravityConstant,
+        s->config.cMinimumAltitude);
+    eng.gravity_vector = BCLIBC_V3dT(0.0, eng.config.cGravityConstant, 0.0);
+}
+
 // ============================================================================
 // Output conversions
 // ============================================================================
 
-static void toC(const BCLIBC_TrajectoryData &s, BCTrajectoryData &d)
+static void toC(const BCLIBC_TrajectoryData &s, BCLIBCFFI_TrajectoryData &d)
 {
     d.time = s.time;
     d.distance_ft = s.distance_ft;
@@ -183,7 +237,7 @@ static void toC(const BCLIBC_TrajectoryData &s, BCTrajectoryData &d)
     d.flag = static_cast<int32_t>(s.flag);
 }
 
-static void toC(const BCLIBC_BaseTrajData &s, BCBaseTrajData &d)
+static void toC(const BCLIBC_BaseTrajData &s, BCLIBCFFI_BaseTrajData &d)
 {
     d.time = s.time;
     d.px = s.px;
@@ -202,7 +256,7 @@ static void toC(const BCLIBC_BaseTrajData &s, BCBaseTrajData &d)
 // Catches all exception types including non-std (catch(...)) across the FFI boundary.
 // C++11 compatible: lambda with -> int32_t trailing return type.
 template <typename Func>
-static int32_t ffi_call(Func &&fn, BCLIBCFFIError *err) noexcept
+static int32_t ffi_call(Func &&fn, BCLIBCFFI_Error *err) noexcept
 {
     clearError(err);
     try
@@ -267,66 +321,63 @@ extern "C"
     }
 
     int32_t BCLIBCFFI_find_apex(
-        const BCShotProps *props,
-        BCTrajectoryData *out,
-        BCLIBCFFIError *err)
+        const BCLIBCFFI_ShotProps *props,
+        BCLIBCFFI_TrajectoryData *out,
+        BCLIBCFFI_Error *err)
     {
         return ffi_call([&]() -> int32_t
-        {
+                        {
             BCLIBC_BaseEngine eng;
             initEngine(eng, props);
             BCLIBC_BaseTrajData apex;
             eng.find_apex(apex);
             toC(BCLIBC_TrajectoryData(eng.shot, apex, BCLIBC_TRAJ_FLAG_APEX), *out);
-            return BCLIBCFFI_OK;
-        }, err);
+            return BCLIBCFFI_OK; }, err);
     }
 
     int32_t BCLIBCFFI_find_max_range(
-        const BCShotProps *props,
+        const BCLIBCFFI_ShotProps *props,
         double low_angle_deg,
         double high_angle_deg,
-        BCMaxRangeResult *out,
-        BCLIBCFFIError *err)
+        BCLIBCFFI_MaxRangeResult *out,
+        BCLIBCFFI_Error *err)
     {
         return ffi_call([&]() -> int32_t
-        {
+                        {
             BCLIBC_BaseEngine eng;
             initEngine(eng, props);
             BCLIBC_MaxRangeResult r = eng.find_max_range(
                 low_angle_deg, high_angle_deg, APEX_IS_MAX_RANGE_RADIANS);
             out->max_range_ft = r.max_range_ft;
             out->angle_at_max_rad = r.angle_at_max_rad;
-            return BCLIBCFFI_OK;
-        }, err);
+            return BCLIBCFFI_OK; }, err);
     }
 
     int32_t BCLIBCFFI_find_zero_angle(
-        const BCShotProps *props,
+        const BCLIBCFFI_ShotProps *props,
         double distance_ft,
         double *out_angle_rad,
-        BCLIBCFFIError *err)
+        BCLIBCFFI_Error *err)
     {
         return ffi_call([&]() -> int32_t
-        {
+                        {
             BCLIBC_BaseEngine eng;
             initEngine(eng, props);
             *out_angle_rad = eng.zero_angle_with_fallback(
                 distance_ft, APEX_IS_MAX_RANGE_RADIANS, ALLOWED_ZERO_ERROR_FEET);
-            return BCLIBCFFI_OK;
-        }, err);
+            return BCLIBCFFI_OK; }, err);
     }
 
     int32_t BCLIBCFFI_integrate(
-        const BCShotProps *props,
-        const BCTrajectoryRequest *request,
-        BCTrajectoryData **out_records,
+        const BCLIBCFFI_ShotProps *props,
+        const BCLIBCFFI_TrajectoryRequest *request,
+        BCLIBCFFI_TrajectoryData **out_records,
         int32_t *out_count,
         int32_t *out_reason,
-        BCLIBCFFIError *err)
+        BCLIBCFFI_Error *err)
     {
         return ffi_call([&]() -> int32_t
-        {
+                        {
             BCLIBC_BaseEngine eng;
             initEngine(eng, props);
 
@@ -343,11 +394,11 @@ extern "C"
                 nullptr);
 
             auto count = static_cast<int32_t>(records.size());
-            BCTrajectoryData *arr = nullptr;
+            BCLIBCFFI_TrajectoryData *arr = nullptr;
             if (count > 0)
             {
-                arr = static_cast<BCTrajectoryData *>(
-                    std::malloc(sizeof(BCTrajectoryData) * static_cast<size_t>(count)));
+                arr = static_cast<BCLIBCFFI_TrajectoryData *>(
+                    std::malloc(sizeof(BCLIBCFFI_TrajectoryData) * static_cast<size_t>(count)));
                 if (!arr)
                 {
                     setError(err, BCLIBCFFI_ERR_GENERIC, "Out of memory allocating trajectory");
@@ -368,24 +419,23 @@ extern "C"
             *out_records = arr;
             *out_count = count;
             *out_reason = static_cast<int32_t>(reason);
-            return BCLIBCFFI_OK;
-        }, err);
+            return BCLIBCFFI_OK; }, err);
     }
 
-    void BCLIBCFFI_free_trajectory(BCTrajectoryData *records)
+    void BCLIBCFFI_free_trajectory(BCLIBCFFI_TrajectoryData *records)
     {
         std::free(records);
     }
 
     int32_t BCLIBCFFI_integrate_at(
-        const BCShotProps *props,
+        const BCLIBCFFI_ShotProps *props,
         int32_t key,
         double target_value,
-        BCInterception *out,
-        BCLIBCFFIError *err)
+        BCLIBCFFI_Interception *out,
+        BCLIBCFFI_Error *err)
     {
         return ffi_call([&]() -> int32_t
-        {
+                        {
             BCLIBC_BaseEngine eng;
             initEngine(eng, props);
 
@@ -397,8 +447,7 @@ extern "C"
 
             toC(raw, out->raw_data);
             toC(full, out->full_data);
-            return BCLIBCFFI_OK;
-        }, err);
+            return BCLIBCFFI_OK; }, err);
     }
 
     double BCLIBCFFI_get_correction(double distance_ft, double offset_ft)
@@ -414,6 +463,135 @@ extern "C"
     double BCLIBCFFI_calculate_ogw(double bullet_weight_grain, double velocity_fps)
     {
         return BCLIBC_calculateOgw(bullet_weight_grain, velocity_fps);
+    }
+
+    // ============================================================================
+    // BCLIBCFFI_Shot variants – all physics conversion in C++ via BCLIBC_Shot::to_shot_props()
+    // ============================================================================
+
+    int32_t BCLIBCFFI_find_apex_shot(
+        const BCLIBCFFI_Shot *shot,
+        BCLIBCFFI_TrajectoryData *out,
+        BCLIBCFFI_Error *err)
+    {
+        return ffi_call([&]() -> int32_t
+                        {
+            BCLIBC_BaseEngine eng;
+            initEngineFromShot(eng, shot);
+            BCLIBC_BaseTrajData apex;
+            eng.find_apex(apex);
+            toC(BCLIBC_TrajectoryData(eng.shot, apex, BCLIBC_TRAJ_FLAG_APEX), *out);
+            return BCLIBCFFI_OK; }, err);
+    }
+
+    int32_t BCLIBCFFI_find_max_range_shot(
+        const BCLIBCFFI_Shot *shot,
+        double low_angle_deg,
+        double high_angle_deg,
+        BCLIBCFFI_MaxRangeResult *out,
+        BCLIBCFFI_Error *err)
+    {
+        return ffi_call([&]() -> int32_t
+                        {
+            BCLIBC_BaseEngine eng;
+            initEngineFromShot(eng, shot);
+            BCLIBC_MaxRangeResult r = eng.find_max_range(
+                low_angle_deg, high_angle_deg, APEX_IS_MAX_RANGE_RADIANS);
+            out->max_range_ft = r.max_range_ft;
+            out->angle_at_max_rad = r.angle_at_max_rad;
+            return BCLIBCFFI_OK; }, err);
+    }
+
+    int32_t BCLIBCFFI_find_zero_angle_shot(
+        const BCLIBCFFI_Shot *shot,
+        double distance_ft,
+        double *out_angle_rad,
+        BCLIBCFFI_Error *err)
+    {
+        return ffi_call([&]() -> int32_t
+                        {
+            BCLIBC_BaseEngine eng;
+            initEngineFromShot(eng, shot);
+            *out_angle_rad = eng.zero_angle_with_fallback(
+                distance_ft, APEX_IS_MAX_RANGE_RADIANS, ALLOWED_ZERO_ERROR_FEET);
+            return BCLIBCFFI_OK; }, err);
+    }
+
+    int32_t BCLIBCFFI_integrate_shot(
+        const BCLIBCFFI_Shot *shot,
+        const BCLIBCFFI_TrajectoryRequest *request,
+        BCLIBCFFI_TrajectoryData **out_records,
+        int32_t *out_count,
+        int32_t *out_reason,
+        BCLIBCFFI_Error *err)
+    {
+        return ffi_call([&]() -> int32_t
+                        {
+            BCLIBC_BaseEngine eng;
+            initEngineFromShot(eng, shot);
+
+            std::vector<BCLIBC_TrajectoryData> records;
+            BCLIBC_TerminationReason reason;
+
+            eng.integrate_filtered(
+                request->range_limit_ft,
+                request->range_step_ft,
+                request->time_step,
+                static_cast<BCLIBC_TrajFlag>(request->filter_flags),
+                records,
+                reason,
+                nullptr);
+
+            auto count = static_cast<int32_t>(records.size());
+            BCLIBCFFI_TrajectoryData *arr = nullptr;
+            if (count > 0)
+            {
+                arr = static_cast<BCLIBCFFI_TrajectoryData *>(
+                    std::malloc(sizeof(BCLIBCFFI_TrajectoryData) * static_cast<size_t>(count)));
+                if (!arr)
+                {
+                    setError(err, BCLIBCFFI_ERR_GENERIC, "Out of memory allocating trajectory");
+                    return BCLIBCFFI_ERR_GENERIC;
+                }
+                try
+                {
+                    for (int32_t i = 0; i < count; ++i)
+                        toC(records[i], arr[i]);
+                }
+                catch (...)
+                {
+                    std::free(arr);
+                    throw;
+                }
+            }
+
+            *out_records = arr;
+            *out_count = count;
+            *out_reason = static_cast<int32_t>(reason);
+            return BCLIBCFFI_OK; }, err);
+    }
+
+    int32_t BCLIBCFFI_integrate_at_shot(
+        const BCLIBCFFI_Shot *shot,
+        int32_t key,
+        double target_value,
+        BCLIBCFFI_Interception *out,
+        BCLIBCFFI_Error *err)
+    {
+        return ffi_call([&]() -> int32_t
+                        {
+            BCLIBC_BaseEngine eng;
+            initEngineFromShot(eng, shot);
+
+            BCLIBC_BaseTrajData raw;
+            BCLIBC_TrajectoryData full;
+            eng.integrate_at(
+                static_cast<BCLIBC_BaseTrajData_InterpKey>(key),
+                target_value, raw, full);
+
+            toC(raw, out->raw_data);
+            toC(full, out->full_data);
+            return BCLIBCFFI_OK; }, err);
     }
 
 } // extern "C"


### PR DESCRIPTION
### Added
- `BCLIBC_Coriolis::from_lat_az(lat_deg, muzzle_velocity_fps, az_deg = NaN)` — static factory; computes all trig pre-computation (sin/cos lat, sin/cos az, range/cross offsets) from geographic degrees; NaN lat → no Coriolis; NaN az → flat-fire drift only
- `BCLIBC_Atmosphere::from_conditions(t_c, p_hpa, alt_ft, humidity = 0.0)` — static factory; CIPM-2007 moist-air density, Rankine Mach formula matching Python `machF()` exactly; p_hpa ≤ 0 → vacuum (zero density, no drag)
- `BCLIBC_cStandardDensityMetric` constant (1.2250 kg/m³) — ICAO sea-level standard density used to normalise CIPM-2007 output
- `BCLIBC_Shot` struct — user-facing shot descriptor (natural units, no pre-computation, non-owning pointers for drag table and winds arrays); `to_shot_props()` assembles engine-ready `BCLIBC_ShotProps` performing all conversions in one place: cant cos/sin, atmosphere, Coriolis, PCHIP drag curve, wind sock
- `BCLIBCFFI_Shot` C struct in `bclibc_ffi.h` — C-compatible mirror of `BCLIBC_Shot` for Dart FFI / other C consumers; takes raw user-facing units (`temp_c`, `pressure_hpa`, `latitude_deg`, `azimuth_deg`) and two parallel `mach_data`/`cd_data` arrays (same layout as `BCLIBC_Shot`); `pressure_hpa == 0` → vacuum
- `BCLIBCFFI_find_apex_shot`, `BCLIBCFFI_find_max_range_shot`, `BCLIBCFFI_find_zero_angle_shot`, `BCLIBCFFI_integrate_shot`, `BCLIBCFFI_integrate_at_shot` — FFI entry points accepting `BCLIBCFFI_Shot`; all physics conversion delegated to `BCLIBC_Shot::to_shot_props()` in C++

### Changed (**breaking** — requires new minor version for all C FFI consumers)
- `bclibc_ffi.h`: all C struct and enum types renamed from `BC*` to `BCLIBCFFI_*` to be consistent with the `BCLIBCFFI_` function prefix:
  - `BCConfig` → `BCLIBCFFI_Config`
  - `BCAtmosphere` → `BCLIBCFFI_Atmosphere`
  - `BCCoriolis` → `BCLIBCFFI_Coriolis`
  - `BCWind` → `BCLIBCFFI_Wind`
  - `BCDragPoint` → `BCLIBCFFI_DragPoint`
  - `BCShotProps` → `BCLIBCFFI_ShotProps`
  - `BCShot` → `BCLIBCFFI_Shot` (also changed `drag_table: BCDragPoint*` to separate `mach_data/cd_data: const double*` arrays, matching `BCLIBC_Shot` layout)
  - `BCTrajFlag` enum → `BCLIBCFFI_TrajFlag`; values `BC_TRAJ_FLAG_*` → `BCLIBCFFI_TRAJ_FLAG_*`
  - `BCTerminationReason` enum → `BCLIBCFFI_TerminationReason`; values `BC_TERM_*` → `BCLIBCFFI_TERM_*`
  - `BCBaseTrajInterpKey` enum → `BCLIBCFFI_BaseTrajInterpKey`; values `BC_INTERP_KEY_*` → `BCLIBCFFI_INTERP_KEY_*`
  - `BCIntegrationMethod` enum → `BCLIBCFFI_IntegrationMethod`; values `BC_INTEGRATION_*` → `BCLIBCFFI_INTEGRATION_*`
  - `BCTrajectoryRequest` → `BCLIBCFFI_TrajectoryRequest`
  - `BCBaseTrajData` → `BCLIBCFFI_BaseTrajData`
  - `BCTrajectoryData` → `BCLIBCFFI_TrajectoryData`
  - `BCMaxRangeResult` → `BCLIBCFFI_MaxRangeResult`
  - `BCInterception` → `BCLIBCFFI_Interception`
  - `BCLIBCFFIStatus` enum → `BCLIBCFFI_Status` (consistent with `BCLIBCFFI_<Name>` pattern)
  - `BCLIBCFFIError` struct → `BCLIBCFFI_Error`
- C++ internal types (`BCLIBC_TRAJ_FLAG_*`, `BCLIBC_Shot`, `BCLIBC_ShotProps`, etc. in `base_types.hpp`) are **unchanged** — this rename affects only the C FFI layer (`bclibc_ffi.h`)