### PR TITLE
fix: vacuum NaN in altitude update, move-construct MachList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.1.0] - 2026-05-26
+## [1.1.1] - 2026-05-29
+
+### Fixed
+- `BCLIBC_Atmosphere::update_density_factor_and_mach_for_altitude()`: added vacuum guard (`_p0 <= 0`) before the barometric formula; previously `_p0 = 0` (set by `from_conditions(p_hpa=0)`) caused `0/0 = NaN` for `density_delta`, propagating NaN drag through any vacuum trajectory where altitude changes by more than 30 ft from base
+- `BCLIBC_Shot::to_shot_props()`: `BCLIBC_MachList` now move-constructed from `mach_v` instead of copy-constructed; eliminates one redundant O(N) heap allocation per shot
+
+## [1.1.0] - 2026-05-28
 
 ### Added
 - `BCLIBC_Coriolis::from_lat_az(lat_deg, muzzle_velocity_fps, az_deg = NaN)` — static factory; computes all trig pre-computation (sin/cos lat, sin/cos az, range/cross offsets) from geographic degrees; NaN lat → no Coriolis; NaN az → flat-fire drift only
@@ -89,7 +95,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ballistics-lab/bclibc/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/ballistics-lab/bclibc/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/ballistics-lab/bclibc/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/ballistics-lab/bclibc/compare/v1.0.5...v1.1.0
 [1.0.5]: https://github.com/ballistics-lab/bclibc/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/ballistics-lab/bclibc/compare/v1.0.3...v1.0.4

--- a/src/base_types.cpp
+++ b/src/base_types.cpp
@@ -530,7 +530,7 @@ namespace bclibc
         std::vector<double> mach_v(mach_data, mach_data + drag_table_size);
         std::vector<double> cd_v(cd_data, cd_data + drag_table_size);
         BCLIBC_Curve curve = build_pchip_curve_from_arrays(mach_v, cd_v);
-        BCLIBC_MachList mach_list = BCLIBC_MachList(mach_v.begin(), mach_v.end());
+        BCLIBC_MachList mach_list = std::move(mach_v);
 
         return BCLIBC_ShotProps(
             bc,
@@ -645,6 +645,16 @@ namespace bclibc
             // Close enough to base altitude, use stored values
             density_ratio_out = this->density_ratio;
             mach_out = this->_mach;
+            return;
+        }
+
+        // Vacuum guard: _p0 == 0 when constructed via from_conditions(p_hpa=0).
+        // The barometric formula divides by _p0 — avoid 0/0 = NaN.
+        // density_ratio is already 0 for vacuum, so the result is unambiguous.
+        if (this->_p0 <= 0.0)
+        {
+            density_ratio_out = 0.0;
+            mach_out = this->_mach; // temperature-based, computed in from_conditions()
             return;
         }
 


### PR DESCRIPTION
## Summary

- **Critical fix**: `update_density_factor_and_mach_for_altitude()` — add `_p0 <= 0` guard before the barometric formula. When a `Vacuum` shot is constructed via `from_conditions(p_hpa=0)`, `_p0` is stored as `0`. The formula then computes `pressure = 0 * pow(...) = 0` and `density_delta = 0/0 = NaN`; `density_ratio_out = 0 * NaN = NaN` propagates through the integrator for any vacuum trajectory where altitude changes more than 30 ft from base. The guard returns `density_ratio_out = 0` and the pre-computed temperature-based `mach_out` immediately.
- **Efficiency fix**: `to_shot_props()` — move-construct `BCLIBC_MachList` from `mach_v` instead of copy-constructing; `mach_v` goes out of scope immediately after, so the copy was allocating N doubles for nothing.

## Root cause

`BCLIBC_Atmosphere::from_conditions(p_hpa=0)` correctly stores `_p0 = 0` to signal vacuum. The fast-path guard in `update_density_factor_and_mach_for_altitude` (< 30 ft altitude diff) returns the stored zero `density_ratio` correctly, but any trajectory step beyond that threshold hit the barometric formula which divides by `_p0` — producing NaN silently.

## Test plan
- [ ] Build and run existing tests: `cmake -B build && cmake --build build && ctest --test-dir build`
- [ ] Verify vacuum trajectory at high angles no longer produces NaN positions
- [ ] Confirm normal (non-vacuum) trajectories are unchanged
