### PR TITLE
fix: add missing traj_data.hpp include in exceptions.hpp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add missing traj_data.hpp include in exceptions.hpp
+
 ## [1.1.2] - 2026-05-29
 
 ### Fixed

--- a/include/bclibc/exceptions.hpp
+++ b/include/bclibc/exceptions.hpp
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include "bclibc/base_types.hpp"
+#include "bclibc/traj_data.hpp"
 
 namespace bclibc
 {


### PR DESCRIPTION
## Summary

- `BCLIBC_InterceptionError` uses `BCLIBC_BaseTrajData` and `BCLIBC_TrajectoryData` as member fields
- `exceptions.hpp` only included `base_types.hpp`, making it unusable as a standalone header
- CI passed only because `engine.cpp` pulled in `traj_data.hpp` transitively

## Fix

Added `#include "bclibc/traj_data.hpp"` directly to `exceptions.hpp`.

Closes #11