### PR TITLE
fix: get_at() extrapolates past trajectory range instead of raising (…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-07-21
+
 ### Fixed
 - `BCLIBC_BaseTrajSeq::get_at()` (`src/traj_data.cpp`) silently extrapolated instead of raising when
   `key_value` was outside the trajectory's range: `bisect_center_idx_buf()`/`find_target_index()` clamp
@@ -227,8 +229,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/ballistics-lab/bclibc/compare/v1.1.4...HEAD
-[1.1.4]: https://github.com/ballistics-lab/bclibc/compare/v1.1.2...v1.1.4
+[Unreleased]: https://github.com/ballistics-lab/bclibc/compare/v1.1.5...HEAD
+[1.1.5]: https://github.com/ballistics-lab/bclibc/compare/v1.1.4...v1.1.5
+[1.1.4]: https://github.com/ballistics-lab/bclibc/compare/v1.1.3...v1.1.4
 [1.1.3]: https://github.com/ballistics-lab/bclibc/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/ballistics-lab/bclibc/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/ballistics-lab/bclibc/compare/v1.1.0...v1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `BCLIBC_BaseTrajSeq::get_at()` (`src/traj_data.cpp`) silently extrapolated instead of raising when
+  `key_value` was outside the trajectory's range: `bisect_center_idx_buf()`/`find_target_index()` clamp
+  their bracket index to `[1, n-2]` regardless of how far `key_value` falls outside the sequence, so
+  `interpolate_at()` only ever validated the *index*, never the *value*. `get_at()` now checks `key_value`
+  against `[min(buffer[0][key], buffer[n-1][key]), max(...)]` (± a `1e-9` epsilon) before searching and
+  throws `std::out_of_range` if it falls outside. ([#19](https://github.com/ballistics-lab/bclibc/issues/19))
+- `pre-commit-check.sh`: artifact check looked for `libbclibc_core.a` in the build root, but
+  `ARCHIVE_OUTPUT_DIRECTORY` in `CMakeLists.txt` places it under `lib/`, so step 3 always failed
+  (silently, since `pr-check.yml` invoked the script with `|| true`). Fixed the expected path.
+
+### Added
+- `tests/`: minimal CTest-based unit test target (`bclibc_tests`) covering `BCLIBC_BaseTrajSeq::get_at()`,
+  wired up via the previously-unused `BCLIBC_BUILD_TESTS` CMake option
+- `make test`: configures with `-DBCLIBC_BUILD_TESTS=ON`, builds, and runs `ctest`
+
+### Changed
+- `pre-commit-check.sh` now builds with `-DBCLIBC_BUILD_TESTS=ON` and runs `ctest` as a required step
+
 ### Removed
 - Deprecated define `-DTINY_BCLIBC_USE_FLOAT` deleted from lib
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,13 @@ if(LINUX_BUILD AND NOT CMAKE_BUILD_TYPE MATCHES "Debug")
     endif()
 endif()
 
+# ============================================================================
+# Tests
+# ============================================================================
+if(BCLIBC_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
 
 # ============================================================================
 # Installation rules

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build core ffi windows windows-debug linux macos clean info
+.PHONY: all build core ffi windows windows-debug linux macos test clean info
 
 # ============================================================================
 # Detect Operating System
@@ -55,6 +55,16 @@ core: cmake-configure
 ffi: cmake-configure
 	cmake --build build --target bclibc_ffi --config Release
 	@echo "FFI library built"
+
+# ============================================================================
+# Tests
+# ============================================================================
+test:
+	mkdir -p build
+	cd build && cmake $(CMAKE_GENERATOR_FLAG) -DCMAKE_BUILD_TYPE=Release -DBCLIBC_BUILD_TESTS=ON ..
+	$(MAKE_COMMAND)
+	cd build && ctest --output-on-failure -C Release
+	@echo "All tests passed"
 
 # ============================================================================
 # Windows Specific Targets

--- a/include/bclibc/traj_data.hpp
+++ b/include/bclibc/traj_data.hpp
@@ -444,6 +444,8 @@ namespace bclibc
          * @param out Output parameter - populated with exact or interpolated trajectory data.
          *
          * @throws std::domain_error if sequence has fewer than 3 points.
+         * @throws std::out_of_range if key_value falls outside the sequence's key range
+         *         (beyond a small epsilon tolerance), which would otherwise require extrapolation.
          * @throws std::logic_error if binary search fails.
          * @throws std::invalid_argument if interpolation encounters duplicate key values.
          *

--- a/pre-commit-check.sh
+++ b/pre-commit-check.sh
@@ -19,12 +19,14 @@ mkdir "$BUILD_DIR"
 cd "$BUILD_DIR"
 
 # Determine library names based on OS
+# LIB_CORE lives under lib/ (ARCHIVE_OUTPUT_DIRECTORY in CMakeLists.txt);
+# LIB_FFI is written to the build root (no LIBRARY_OUTPUT_DIRECTORY override).
 if [[ "$OS" == "Darwin" ]]; then
-    LIB_CORE="libbclibc_core.a"
+    LIB_CORE="lib/libbclibc_core.a"
     LIB_FFI="libbclibc_ffi.dylib"
     NM_CMD="nm -g"
 elif [[ "$OS" == "Linux" ]]; then
-    LIB_CORE="libbclibc_core.a"
+    LIB_CORE="lib/libbclibc_core.a"
     LIB_FFI="libbclibc_ffi.so"
     NM_CMD="nm -D"
 else
@@ -33,15 +35,24 @@ else
 fi
 
 # Compile with redirection of errors and warnings to a file
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBCLIBC_BUILD_TESTS=ON ..
 if [[ "$OS" == "Darwin" ]]; then
     make -j$(sysctl -n hw.ncpu) 2> build_warnings.log || (cat build_warnings.log && exit 1)
 else
     make -j$(nproc) 2> build_warnings.log || (cat build_warnings.log && exit 1)
 fi
 
-# 2. Check for artifacts
-echo -e "\n${GREEN}2. Checking build artifacts...${NC}"
+# 2. Run unit tests
+echo -e "\n${GREEN}2. Running unit tests...${NC}"
+if ctest --output-on-failure; then
+    echo -e "   ${GREEN}[OK]${NC} All tests passed."
+else
+    echo -e "   ${RED}[FAIL]${NC} Test failures detected!"
+    exit 1
+fi
+
+# 3. Check for artifacts
+echo -e "\n${GREEN}3. Checking build artifacts...${NC}"
 if [ -f "$LIB_CORE" ] && [ -f "$LIB_FFI" ]; then
     echo -e "   ${GREEN}[OK]${NC} Libraries found."
 else
@@ -49,8 +60,8 @@ else
     exit 1
 fi
 
-# 3. Check for warnings (Zero Warning Policy)
-echo -e "\n${GREEN}3. Validating warnings...${NC}"
+# 4. Check for warnings (Zero Warning Policy)
+echo -e "\n${GREEN}4. Validating warnings...${NC}"
 if [ -s build_warnings.log ]; then
     echo -e "   ${YELLOW}[WARNING]${NC} Warnings detected during build:"
     cat build_warnings.log
@@ -60,8 +71,8 @@ else
     echo -e "   ${GREEN}[OK]${NC} No warnings detected."
 fi
 
-# 4. Checking the version (extracting from the binary)
-echo -e "\n${GREEN}4. Checking version metadata...${NC}"
+# 5. Checking the version (extracting from the binary)
+echo -e "\n${GREEN}5. Checking version metadata...${NC}"
 
 # Get the expected version from the generated header
 if [ -f "generated/bclibc/version.h" ]; then
@@ -87,8 +98,8 @@ else
     exit 1
 fi
 
-# 5. Check symbols export (whitelist BCLIBCFFI_)
-echo -e "\n${GREEN}5. Validating exported symbols...${NC}"
+# 6. Check symbols export (whitelist BCLIBCFFI_)
+echo -e "\n${GREEN}6. Validating exported symbols...${NC}"
 
 if [[ "$OS" == "Darwin" ]]; then
     # macOS uses different symbol checking
@@ -105,9 +116,9 @@ else
     exit 1
 fi
 
-# 6. Check symlinks (Linux only)
+# 7. Check symlinks (Linux only)
 if [[ "$OS" == "Linux" ]]; then
-    echo -e "\n${GREEN}6. Checking SOVERSION symlinks...${NC}"
+    echo -e "\n${GREEN}7. Checking SOVERSION symlinks...${NC}"
     if ls libbclibc_ffi.so.[0-9]* 1> /dev/null 2>&1; then
         echo -e "   ${GREEN}[OK]${NC} Symlinks are generated."
     else

--- a/src/traj_data.cpp
+++ b/src/traj_data.cpp
@@ -394,6 +394,8 @@ namespace bclibc
      * @param out Output parameter - populated with exact or interpolated trajectory data.
      *
      * @throws std::domain_error if sequence has fewer than 3 points.
+     * @throws std::out_of_range if key_value falls outside the sequence's key range
+     *         (beyond a small epsilon tolerance), which would otherwise require extrapolation.
      * @throws std::logic_error if binary search fails.
      * @throws std::invalid_argument if interpolation encounters duplicate key values.
      *
@@ -411,6 +413,22 @@ namespace bclibc
         if (n < 3)
         {
             throw std::domain_error("Insufficient data points for interpolation (need >= 3)");
+        }
+
+        // Reject queries outside the sequence's key range before searching. Without this,
+        // bisect_center_idx_buf()/find_target_index() clamp their result index to [1, n-2] and
+        // get_at() would happily extrapolate through the boundary bracket instead of signaling
+        // that the trajectory never reaches key_value.
+        {
+            const double v0 = this->buffer[0][key_kind];
+            const double vN = this->buffer[n - 1][key_kind];
+            const double range_lo = (v0 <= vN) ? v0 : vN;
+            const double range_hi = (v0 <= vN) ? vN : v0;
+            constexpr double range_epsilon = 1e-9;
+            if (key_value < range_lo - range_epsilon || key_value > range_hi + range_epsilon)
+            {
+                throw std::out_of_range("key_value is outside the trajectory's range");
+            }
         }
 
         ssize_t target_idx = -1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.13)
+
+add_executable(bclibc_tests
+    test_traj_data.cpp
+)
+
+target_link_libraries(bclibc_tests PRIVATE bclibc_core)
+target_compile_features(bclibc_tests PRIVATE cxx_std_17)
+
+add_test(NAME bclibc_tests COMMAND bclibc_tests)

--- a/tests/test_traj_data.cpp
+++ b/tests/test_traj_data.cpp
@@ -1,0 +1,153 @@
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <stdexcept>
+#include "bclibc/traj_data.hpp"
+
+using namespace bclibc;
+
+namespace
+{
+    BCLIBC_BaseTrajSeq make_increasing_seq()
+    {
+        // position.x runs 0..4, matching the repro from GitHub issue #19.
+        BCLIBC_BaseTrajSeq seq;
+        for (int t = 0; t < 5; ++t)
+        {
+            seq.append(BCLIBC_BaseTrajData(
+                static_cast<double>(t), static_cast<double>(t), 0.0, 0.0,
+                100.0, 0.0, 0.0, 1.0));
+        }
+        return seq;
+    }
+
+    BCLIBC_BaseTrajSeq make_decreasing_seq()
+    {
+        // position.x runs 4..0 (decreasing), to exercise the other monotonic branch.
+        BCLIBC_BaseTrajSeq seq;
+        for (int t = 0; t < 5; ++t)
+        {
+            seq.append(BCLIBC_BaseTrajData(
+                static_cast<double>(t), static_cast<double>(4 - t), 0.0, 0.0,
+                100.0, 0.0, 0.0, 1.0));
+        }
+        return seq;
+    }
+
+    // GitHub issue #19: get_at() must raise instead of silently extrapolating
+    // when key_value falls outside the sequence's range.
+    void test_get_at_rejects_out_of_range_above_increasing()
+    {
+        auto seq = make_increasing_seq();
+        BCLIBC_BaseTrajData out;
+        bool threw = false;
+        try
+        {
+            seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, 104.0, 0.0, out);
+        }
+        catch (const std::out_of_range &)
+        {
+            threw = true;
+        }
+        assert(threw && "expected std::out_of_range for value above range");
+    }
+
+    void test_get_at_rejects_out_of_range_below_increasing()
+    {
+        auto seq = make_increasing_seq();
+        BCLIBC_BaseTrajData out;
+        bool threw = false;
+        try
+        {
+            seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, -10.0, 0.0, out);
+        }
+        catch (const std::out_of_range &)
+        {
+            threw = true;
+        }
+        assert(threw && "expected std::out_of_range for value below range");
+    }
+
+    void test_get_at_rejects_out_of_range_decreasing()
+    {
+        auto seq = make_decreasing_seq();
+        BCLIBC_BaseTrajData out;
+        bool threw = false;
+        try
+        {
+            seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, -1.0, 0.0, out);
+        }
+        catch (const std::out_of_range &)
+        {
+            threw = true;
+        }
+        assert(threw && "expected std::out_of_range for value beyond a decreasing sequence");
+    }
+
+    void test_get_at_interpolates_in_range()
+    {
+        auto seq = make_increasing_seq();
+        BCLIBC_BaseTrajData out;
+        seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, 2.5, 0.0, out);
+        assert(std::fabs(out.px - 2.5) < 1e-9);
+    }
+
+    void test_get_at_matches_exact_endpoints()
+    {
+        auto seq = make_increasing_seq();
+        BCLIBC_BaseTrajData out;
+
+        seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, 0.0, 0.0, out);
+        assert(std::fabs(out.px - 0.0) < 1e-9);
+
+        seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, 4.0, 0.0, out);
+        assert(std::fabs(out.px - 4.0) < 1e-9);
+    }
+
+    // A boundary value that's outside by only floating-point dust must still
+    // resolve rather than being rejected by the new range check.
+    void test_get_at_tolerates_epsilon_boundary_jitter()
+    {
+        auto seq = make_increasing_seq();
+        BCLIBC_BaseTrajData out;
+
+        seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, 4.0 + 1e-10, 0.0, out);
+        assert(std::fabs(out.px - 4.0) < 1e-6);
+
+        seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, 0.0 - 1e-10, 0.0, out);
+        assert(std::fabs(out.px - 0.0) < 1e-6);
+    }
+
+    void test_get_at_requires_at_least_three_points()
+    {
+        BCLIBC_BaseTrajSeq seq;
+        seq.append(BCLIBC_BaseTrajData(0.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 1.0));
+        seq.append(BCLIBC_BaseTrajData(1.0, 1.0, 0.0, 0.0, 100.0, 0.0, 0.0, 1.0));
+
+        BCLIBC_BaseTrajData out;
+        bool threw = false;
+        try
+        {
+            seq.get_at(BCLIBC_BaseTrajData_InterpKey::POS_X, 0.5, 0.0, out);
+        }
+        catch (const std::domain_error &)
+        {
+            threw = true;
+        }
+        assert(threw && "expected std::domain_error for fewer than 3 points");
+    }
+}
+
+int main()
+{
+    test_get_at_rejects_out_of_range_above_increasing();
+    test_get_at_rejects_out_of_range_below_increasing();
+    test_get_at_rejects_out_of_range_decreasing();
+    test_get_at_interpolates_in_range();
+    test_get_at_matches_exact_endpoints();
+    test_get_at_tolerates_epsilon_boundary_jitter();
+    test_get_at_requires_at_least_three_points();
+
+    std::printf("test_traj_data: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- `BCLIBC_BaseTrajSeq::get_at()` clamped its search index to `[1, n-2]` without ever checking `key_value` against the sequence's actual key range, so out-of-range queries silently returned extrapolated garbage instead of erroring. It now throws `std::out_of_range` when `key_value` falls outside `[min(first, last), max(first, last)]` (± a `1e-9` epsilon).
- Adds a minimal CTest-based test target (`tests/`), wired up via the previously-unused `BCLIBC_BUILD_TESTS` CMake option, covering the fix plus existing `get_at()` behavior (in-range interpolation, exact endpoints, increasing/decreasing sequences, `n<3` guard).
- `make test` and `pre-commit-check.sh` now build with tests enabled and run `ctest` as a required step.
- Fixes an unrelated pre-existing bug in `pre-commit-check.sh`: its artifact check looked for `libbclibc_core.a` in the build root instead of `lib/` (per `ARCHIVE_OUTPUT_DIRECTORY`), so that check had been silently failing (masked by `pr-check.yml` invoking the script with `|| true`).

Closes: #19

## Test plan
- [x] `make test` - builds with `BCLIBC_BUILD_TESTS=ON`, `ctest` passes
- [x] `./pre-commit-check.sh` — all 7 checks pass, including the previously-broken artifact check
- [x] Default build (`BCLIBC_BUILD_TESTS` off) still configures/builds unaffected
